### PR TITLE
feat: add ability to configure a persistent host key

### DIFF
--- a/cmd/ssh-portal/serve.go
+++ b/cmd/ssh-portal/serve.go
@@ -15,8 +15,11 @@ import (
 
 // ServeCmd represents the serve command.
 type ServeCmd struct {
-	NATSServer    string `kong:"required,env='NATS_URL',help='NATS server URL (nats://... or tls://...)'"`
-	SSHServerPort uint   `kong:"default='2222',env='SSH_SERVER_PORT',help='Port the SSH server will listen on for SSH client connections'"`
+	NATSServer     string `kong:"required,env='NATS_URL',help='NATS server URL (nats://... or tls://...)'"`
+	SSHServerPort  uint   `kong:"default='2222',env='SSH_SERVER_PORT',help='Port the SSH server will listen on for SSH client connections'"`
+	HostKeyECDSA   string `kong:"env='HOST_KEY_ECDSA',help='PEM encoded ECDSA host key'"`
+	HostKeyED25519 string `kong:"env='HOST_KEY_ED25519',help='PEM encoded Ed25519 host key'"`
+	HostKeyRSA     string `kong:"env='HOST_KEY_RSA',help='PEM encoded RSA host key'"`
 }
 
 // Run the serve command to service API requests.
@@ -45,6 +48,13 @@ func (cmd *ServeCmd) Run(log *zap.Logger) error {
 	if err != nil {
 		return fmt.Errorf("couldn't create k8s client: %v", err)
 	}
+	// check for persistent host key arguments
+	var hostkeys [][]byte
+	for _, hk := range []string{cmd.HostKeyECDSA, cmd.HostKeyED25519, cmd.HostKeyRSA} {
+		if len(hk) > 0 {
+			hostkeys = append(hostkeys, []byte(hk))
+		}
+	}
 	// start serving SSH connection requests
-	return sshserver.Serve(ctx, log, nc, l, c)
+	return sshserver.Serve(ctx, log, nc, l, c, hostkeys)
 }

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/google/uuid v1.3.0
 	github.com/jmoiron/sqlx v1.3.4
+	github.com/moby/spdystream v0.2.0
 	github.com/nats-io/nats.go v1.13.1-0.20211018182449-f2416a8b1483
 	github.com/prometheus/client_golang v1.11.0
 	go.opentelemetry.io/otel v1.3.0
@@ -34,7 +35,6 @@ require (
 	github.com/googleapis/gnostic v0.5.5 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
-	github.com/moby/spdystream v0.2.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/nats-io/nats-server/v2 v2.6.4 // indirect


### PR DESCRIPTION
If no host key is defined, a non-persistent host key will be generated
at server start.