### PR TITLE
feat: send session ID in query to service-api

### DIFF
--- a/internal/serviceapi/sshportal.go
+++ b/internal/serviceapi/sshportal.go
@@ -24,6 +24,7 @@ type SSHAccessQuery struct {
 	NamespaceName  string
 	ProjectID      int
 	EnvironmentID  int
+	SessionID      string
 }
 
 var (

--- a/internal/sshserver/authhandler.go
+++ b/internal/sshserver/authhandler.go
@@ -59,6 +59,7 @@ func pubKeyAuth(log *zap.Logger, nc *nats.Conn,
 			NamespaceName:  ctx.User(),
 			ProjectID:      pid,
 			EnvironmentID:  eid,
+			SessionID:      ctx.SessionID(),
 		})
 		if err != nil {
 			log.Warn("couldn't marshal SSHAccessQuery",


### PR DESCRIPTION
This facilitates tracing and log correlation.