### PR TITLE
fix: handle NATS connection closing itself

### DIFF
--- a/cmd/service-api/serve.go
+++ b/cmd/service-api/serve.go
@@ -57,6 +57,6 @@ func (cmd *ServeCmd) Run(log *zap.Logger) error {
 		return fmt.Errorf("couldn't init keycloak Client: %v", err)
 	}
 	// start serving NATS requests
-	return serviceapi.ServeNATS(ctx, log, l, k, cmd.NATSURL, cmd.NATSUsername,
-		cmd.NATSPassword)
+	return serviceapi.ServeNATS(ctx, stop, log, l, k, cmd.NATSURL,
+		cmd.NATSUsername, cmd.NATSPassword)
 }

--- a/internal/serviceapi/server.go
+++ b/internal/serviceapi/server.go
@@ -28,8 +28,9 @@ type KeycloakService interface {
 }
 
 // ServeNATS serviceapi NATS requests.
-func ServeNATS(ctx context.Context, log *zap.Logger, l LagoonDBService,
-	k KeycloakService, natsURL, natsUser, natsPass string) error {
+func ServeNATS(ctx context.Context, stop context.CancelFunc, log *zap.Logger,
+	l LagoonDBService, k KeycloakService, natsURL, natsUser,
+	natsPass string) error {
 	// setup synchronisation
 	wg := sync.WaitGroup{}
 	wg.Add(1)
@@ -37,6 +38,7 @@ func ServeNATS(ctx context.Context, log *zap.Logger, l LagoonDBService,
 	nc, err := nats.Connect(natsURL,
 		// synchronise exiting ServeNATS()
 		nats.ClosedHandler(func(_ *nats.Conn) {
+			stop()
 			wg.Done()
 		}),
 		// pass credentials

--- a/internal/serviceapi/server.go
+++ b/internal/serviceapi/server.go
@@ -60,7 +60,7 @@ func ServeNATS(ctx context.Context, stop context.CancelFunc, log *zap.Logger,
 	<-ctx.Done()
 	// drain and log errors
 	if err := c.Drain(); err != nil {
-		log.Error("couldn't drain connection", zap.Error(err))
+		log.Warn("couldn't drain connection", zap.Error(err))
 	}
 	// wait for connection to close
 	wg.Wait()


### PR DESCRIPTION
If the NATS server restarts then the connection will close itself due to
authorization failures. Previously the connection closing itself instead
of being instigated by service-api could lead to a deadlock by blocking
on <-ctx.Done().

This change cancels the context in the NATS connection closed handler to
avoid the deadlock.