### PR TITLE
chore: add some debug logging for NATS connect errors

### DIFF
--- a/internal/serviceapi/server.go
+++ b/internal/serviceapi/server.go
@@ -44,6 +44,8 @@ func ServeNATS(ctx context.Context, stop context.CancelFunc, log *zap.Logger,
 		// pass credentials
 		nats.UserInfo(natsUser, natsPass))
 	if err != nil {
+		log.Debug("NATS connect error", zap.Error(err),
+			zap.String("user", natsUser), zap.String("pass", natsPass))
 		return fmt.Errorf("couldn't connect to NATS server: %v", err)
 	}
 	c, err := nats.NewEncodedConn(nc, "json")


### PR DESCRIPTION
Occasionally service-api gets into a crashloop with this error
```
service-api: error: couldn't connect to NATS server: nats: Authorization Violation
```

This logging should help to debug this case.