### PR TITLE
feat: rename service-api to ssh-portal-api

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         binary:
-        - service-api
+        - ssh-portal-api
         - ssh-portal
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -68,7 +68,7 @@ jobs:
     strategy:
       matrix:
         binary:
-        - service-api
+        - ssh-portal-api
         - ssh-portal
     needs:
     - tag

--- a/.github/workflows/tag-to-release.yaml
+++ b/.github/workflows/tag-to-release.yaml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         binary:
-        - service-api
+        - ssh-portal-api
         - ssh-portal
     needs:
     - tag

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,7 +1,7 @@
 builds:
-- id: service-api
-  dir: cmd/service-api
-  binary: service-api
+- id: ssh-portal-api
+  dir: cmd/ssh-portal-api
+  binary: ssh-portal-api
   ldflags:
   - >
     -s -w -X main.date={{.Date}} -X "main.goVersion={{.Env.GOVERSION}}"

--- a/README.md
+++ b/README.md
@@ -8,23 +8,23 @@ This is an experimental cluster-local SSH service for [Lagoon](https://github.co
 
 ## Architecture
 
-The Lagoon SSH portal is implemented as a pair of services: `service-api`, and `ssh-portal`.
+The Lagoon SSH portal is implemented as a pair of services: `ssh-portal-api`, and `ssh-portal`.
 These two services communicate over a backend messaging system.
 Currently the message system used is [NATS](https://nats.io/).
 
-There may be many instances of `ssh-portal` in many remote clusters communicating back to the `service-api`.
+There may be many instances of `ssh-portal` in many remote clusters communicating back to the `ssh-portal-api` in the core cluster.
 
-### Service API
+### SSH Portal API
 
-`service-api` is part of Lagoon Core, and serves requests from the `ssh-portal` service, which may be in a remote cluster.
+`ssh-portal-api` is part of Lagoon Core, and serves requests from the `ssh-portal` service, which may be in a remote cluster.
 
-`service-api` is explicitly _not_ a public API and makes no guarantees about compatiblity.
-It is _only_ designed to cater to the requirements of `ssh-portal`, and potentially other internal Lagoon services in future.
+`ssh-portal-api` is explicitly _not_ a public API and makes no guarantees about compatiblity.
+It is _only_ designed to cater to the requirements of `ssh-portal`.
 
 ### SSH Portal
 
 `ssh-portal` is part of Lagoon Remote, and implements an SSH server which connects incoming SSH sessions with pods running in the cluster.
-To perform authentication it communicates back to `service-api` running in Lagoon Core, which responds with a true/false if the SSH key is valid for the requested Lagoon environment.
+To perform authentication it communicates back to `ssh-portal-api` running in Lagoon Core, which responds with a true/false if the SSH key is valid for the requested Lagoon environment.
 
 `ssh-portal` implements shell access with service and container selection [as described in the Lagoon documentation](https://docs.lagoon.sh/using-lagoon-advanced/ssh/#ssh-into-a-pod), but it does not implement token generation.
 
@@ -34,5 +34,5 @@ Unlike the existing Lagoon SSH service, `ssh-portal` _only_ provides access to L
 
 If a user gets an error from `ssh-portal` it may not contain much detail for security reasons.
 However it _will_ contain a Session ID (SID).
-The SID is logged by the `ssh-portal`, and is also passed to the `service-api` and logged there too.
-This helps to correlate error messages in `ssh-portal` and `service-api` logs with user connection errors.
+The SID is logged by the `ssh-portal`, and is also passed to the `ssh-portal-api` and logged there too.
+This helps to correlate error messages in `ssh-portal` and `ssh-portal-api` logs with user connection errors.

--- a/cmd/ssh-portal-api/main.go
+++ b/cmd/ssh-portal-api/main.go
@@ -8,7 +8,7 @@ import (
 // CLI represents the command-line interface.
 type CLI struct {
 	Debug   bool       `kong:"env='DEBUG',help='Enable debug logging'"`
-	Serve   ServeCmd   `kong:"cmd,default=1,help='(default) Serve service-api requests'"`
+	Serve   ServeCmd   `kong:"cmd,default=1,help='(default) Serve ssh-portal-api requests'"`
 	Version VersionCmd `kong:"cmd,help='Print version information'"`
 }
 

--- a/cmd/ssh-portal-api/serve.go
+++ b/cmd/ssh-portal-api/serve.go
@@ -10,7 +10,7 @@ import (
 	"github.com/uselagoon/ssh-portal/internal/keycloak"
 	"github.com/uselagoon/ssh-portal/internal/lagoondb"
 	"github.com/uselagoon/ssh-portal/internal/metrics"
-	"github.com/uselagoon/ssh-portal/internal/serviceapi"
+	"github.com/uselagoon/ssh-portal/internal/sshportalapi"
 	"go.uber.org/zap"
 )
 
@@ -24,11 +24,11 @@ type ServeCmd struct {
 	KeycloakClientID     string `kong:"default='service-api',env='KEYCLOAK_SERVICE_API_CLIENT_ID',help='Keycloak OAuth2 Client ID'"`
 	KeycloakClientSecret string `kong:"required,env='KEYCLOAK_SERVICE_API_CLIENT_SECRET',help='Keycloak OAuth2 Client Secret'"`
 	NATSURL              string `kong:"required,env='NATS_URL',help='NATS server URL (nats://... or tls://...)'"`
-	NATSUsername         string `kong:"default='service-api',env='NATS_USERNAME',help='NATS Username'"`
-	NATSPassword         string `kong:"default='service-api',env='NATS_PASSWORD',help='NATS Password'"`
+	NATSUsername         string `kong:"default='ssh-portal-api',env='NATS_USERNAME',help='NATS Username'"`
+	NATSPassword         string `kong:"default='ssh-portal-api',env='NATS_PASSWORD',help='NATS Password'"`
 }
 
-// Run the serve command to service API requests.
+// Run the serve command to ssh-portal API requests.
 func (cmd *ServeCmd) Run(log *zap.Logger) error {
 	// instrumentation requires a separate context because deferred Shutdown()
 	// will exit immediately if the context is already done.
@@ -57,6 +57,6 @@ func (cmd *ServeCmd) Run(log *zap.Logger) error {
 		return fmt.Errorf("couldn't init keycloak Client: %v", err)
 	}
 	// start serving NATS requests
-	return serviceapi.ServeNATS(ctx, stop, log, l, k, cmd.NATSURL,
+	return sshportalapi.ServeNATS(ctx, stop, log, l, k, cmd.NATSURL,
 		cmd.NATSUsername, cmd.NATSPassword)
 }

--- a/cmd/ssh-portal-api/version.go
+++ b/cmd/ssh-portal-api/version.go
@@ -14,7 +14,7 @@ type VersionCmd struct{}
 
 // Run the version command to print version information.
 func (cmd *VersionCmd) Run() error {
-	fmt.Printf("Lagoon service-api %v (%v) compiled with %v on %v\n", version,
+	fmt.Printf("Lagoon ssh-portal-api %v (%v) compiled with %v on %v\n", version,
 		shortCommit, goVersion, date)
 	return nil
 }

--- a/cmd/ssh-portal/main.go
+++ b/cmd/ssh-portal/main.go
@@ -9,7 +9,7 @@ import (
 // CLI represents the command-line interface.
 type CLI struct {
 	Debug   bool       `kong:"env='DEBUG',help='Enable debug logging'"`
-	Serve   ServeCmd   `kong:"cmd,default=1,help='(default) Serve service-api requests'"`
+	Serve   ServeCmd   `kong:"cmd,default=1,help='(default) Serve ssh-portal requests'"`
 	Version VersionCmd `kong:"cmd,help='Print version information'"`
 }
 

--- a/cmd/ssh-portal/serve.go
+++ b/cmd/ssh-portal/serve.go
@@ -23,7 +23,7 @@ type ServeCmd struct {
 	HostKeyRSA     string `kong:"env='HOST_KEY_RSA',help='PEM encoded RSA host key'"`
 }
 
-// Run the serve command to service API requests.
+// Run the serve command to handle SSH connection requests.
 func (cmd *ServeCmd) Run(log *zap.Logger) error {
 	// instrumentation requires a separate context because deferred Shutdown()
 	// will exit immediately if the context is already done.

--- a/cmd/ssh-portal/version.go
+++ b/cmd/ssh-portal/version.go
@@ -14,7 +14,7 @@ type VersionCmd struct{}
 
 // Run the version command to print version information.
 func (cmd *VersionCmd) Run() error {
-	fmt.Printf("Lagoon service-api %v (%v) compiled with %v on %v\n", version,
+	fmt.Printf("Lagoon ssh-portal %v (%v) compiled with %v on %v\n", version,
 		shortCommit, goVersion, date)
 	return nil
 }

--- a/deploy/service-api/Dockerfile
+++ b/deploy/service-api/Dockerfile
@@ -1,3 +1,0 @@
-FROM alpine:3.14
-ENTRYPOINT ["/service-api"]
-COPY service-api /

--- a/deploy/ssh-portal-api/Dockerfile
+++ b/deploy/ssh-portal-api/Dockerfile
@@ -1,0 +1,3 @@
+FROM alpine:3.14
+ENTRYPOINT ["/ssh-portal-api"]
+COPY ssh-portal-api /

--- a/internal/sshportalapi/server.go
+++ b/internal/sshportalapi/server.go
@@ -1,4 +1,4 @@
-package serviceapi
+package sshportalapi
 
 import (
 	"context"
@@ -12,8 +12,8 @@ import (
 )
 
 const (
-	queue   = "serviceapi"
-	pkgName = "github.com/uselagoon/ssh-portal/internal/serviceapi"
+	queue   = "sshportalapi"
+	pkgName = "github.com/uselagoon/ssh-portal/internal/sshportalapi"
 )
 
 // LagoonDBService provides methods for querying the Lagoon API DB.
@@ -27,7 +27,7 @@ type KeycloakService interface {
 	UserRolesAndGroups(context.Context, *uuid.UUID) ([]string, []string, map[string][]int, error)
 }
 
-// ServeNATS serviceapi NATS requests.
+// ServeNATS sshportalapi NATS requests.
 func ServeNATS(ctx context.Context, stop context.CancelFunc, log *zap.Logger,
 	l LagoonDBService, k KeycloakService, natsURL, natsUser,
 	natsPass string) error {

--- a/internal/sshportalapi/sshportal.go
+++ b/internal/sshportalapi/sshportal.go
@@ -1,4 +1,4 @@
-package serviceapi
+package sshportalapi
 
 import (
 	"context"
@@ -15,7 +15,7 @@ import (
 
 const (
 	// SubjectSSHAccessQuery defines the NATS subject for SSH access queries.
-	SubjectSSHAccessQuery = "lagoon.serviceapi.sshportal"
+	SubjectSSHAccessQuery = "lagoon.sshportal.api"
 )
 
 // SSHAccessQuery defines the structure of an SSH access query.
@@ -29,7 +29,7 @@ type SSHAccessQuery struct {
 
 var (
 	requestsCounter = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "serviceapi_requests_total",
+		Name: "sshportalapi_requests_total",
 		Help: "The total number of requests received",
 	})
 )

--- a/internal/sshserver/authhandler.go
+++ b/internal/sshserver/authhandler.go
@@ -10,7 +10,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/uselagoon/ssh-portal/internal/k8s"
-	"github.com/uselagoon/ssh-portal/internal/serviceapi"
+	"github.com/uselagoon/ssh-portal/internal/sshportalapi"
 	"go.uber.org/zap"
 	gossh "golang.org/x/crypto/ssh"
 )
@@ -54,7 +54,7 @@ func pubKeyAuth(log *zap.Logger, nc *nats.Conn,
 		}
 		// construct and marshal ssh access query
 		fingerprint := gossh.FingerprintSHA256(pubKey)
-		data, err := json.Marshal(&serviceapi.SSHAccessQuery{
+		data, err := json.Marshal(&sshportalapi.SSHAccessQuery{
 			SSHFingerprint: fingerprint,
 			NamespaceName:  ctx.User(),
 			ProjectID:      pid,
@@ -68,7 +68,7 @@ func pubKeyAuth(log *zap.Logger, nc *nats.Conn,
 			return false
 		}
 		// send query
-		response, err := nc.Request(serviceapi.SubjectSSHAccessQuery, data,
+		response, err := nc.Request(sshportalapi.SubjectSSHAccessQuery, data,
 			natsTimeout)
 		if err != nil {
 			log.Warn("couldn't make NATS request",


### PR DESCRIPTION
This change clarifies the concept of having independent microservices
implementing individual features in Lagoon.