### PR TITLE
feat: disable NATS auth for ssh-portal-api

### DIFF
--- a/cmd/ssh-portal-api/serve.go
+++ b/cmd/ssh-portal-api/serve.go
@@ -24,8 +24,6 @@ type ServeCmd struct {
 	KeycloakClientID     string `kong:"default='service-api',env='KEYCLOAK_SERVICE_API_CLIENT_ID',help='Keycloak OAuth2 Client ID'"`
 	KeycloakClientSecret string `kong:"required,env='KEYCLOAK_SERVICE_API_CLIENT_SECRET',help='Keycloak OAuth2 Client Secret'"`
 	NATSURL              string `kong:"required,env='NATS_URL',help='NATS server URL (nats://... or tls://...)'"`
-	NATSUsername         string `kong:"default='ssh-portal-api',env='NATS_USERNAME',help='NATS Username'"`
-	NATSPassword         string `kong:"default='ssh-portal-api',env='NATS_PASSWORD',help='NATS Password'"`
 }
 
 // Run the serve command to ssh-portal API requests.
@@ -57,6 +55,5 @@ func (cmd *ServeCmd) Run(log *zap.Logger) error {
 		return fmt.Errorf("couldn't init keycloak Client: %v", err)
 	}
 	// start serving NATS requests
-	return sshportalapi.ServeNATS(ctx, stop, log, l, k, cmd.NATSURL,
-		cmd.NATSUsername, cmd.NATSPassword)
+	return sshportalapi.ServeNATS(ctx, stop, log, l, k, cmd.NATSURL)
 }

--- a/internal/sshportalapi/server.go
+++ b/internal/sshportalapi/server.go
@@ -29,8 +29,7 @@ type KeycloakService interface {
 
 // ServeNATS sshportalapi NATS requests.
 func ServeNATS(ctx context.Context, stop context.CancelFunc, log *zap.Logger,
-	l LagoonDBService, k KeycloakService, natsURL, natsUser,
-	natsPass string) error {
+	l LagoonDBService, k KeycloakService, natsURL string) error {
 	// setup synchronisation
 	wg := sync.WaitGroup{}
 	wg.Add(1)
@@ -40,12 +39,8 @@ func ServeNATS(ctx context.Context, stop context.CancelFunc, log *zap.Logger,
 		nats.ClosedHandler(func(_ *nats.Conn) {
 			stop()
 			wg.Done()
-		}),
-		// pass credentials
-		nats.UserInfo(natsUser, natsPass))
+		}))
 	if err != nil {
-		log.Debug("NATS connect error", zap.Error(err),
-			zap.String("user", natsUser), zap.String("pass", natsPass))
 		return fmt.Errorf("couldn't connect to NATS server: %v", err)
 	}
 	c, err := nats.NewEncodedConn(nc, "json")


### PR DESCRIPTION
Significantly simplify some tricky state in the Lagoon charts by not
using user/password authentication for local connections to NATS. The
NATS service is namespace-local and protected by NetworkPolicy, so it is
still protected.

This does not affect authentication and encryption used by Lagoon Remote
NATS leaf clusters connecting to the Lagoon Core NATS cluster. Leaf
cluster connections are still authenticated and encrypted.