### PR TITLE
feat: validate the JWT signing algorithm manually

### DIFF
--- a/internal/keycloak/client.go
+++ b/internal/keycloak/client.go
@@ -138,6 +138,11 @@ func (c *Client) UserRolesAndGroups(ctx context.Context,
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("couldn't parse user account token: %v", err)
 	}
+	if tok.Method.Alg() != jwt.SigningMethodRS256.Alg() {
+		return nil, nil, nil,
+			fmt.Errorf("unexepcted token signing algorithm: expected %s, got %s",
+				jwt.SigningMethodRS256.Alg(), tok.Method.Alg())
+	}
 	claims, ok := tok.Claims.(*SSHAPIClaims)
 	if !ok {
 		return nil, nil, nil, fmt.Errorf("invalid token claims type: %T", tok.Claims)


### PR DESCRIPTION
The signing algorithm is checked against the provided key, so there should not be any possibility of falling victim to `alg: none`, but check manually too just to be sure.