### PR TITLE
feat: rename metrics to avoid duplicate names

### DIFF
--- a/internal/sshportalapi/sshportal.go
+++ b/internal/sshportalapi/sshportal.go
@@ -30,7 +30,7 @@ type SSHAccessQuery struct {
 var (
 	requestsCounter = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "sshportalapi_requests_total",
-		Help: "The total number of requests received",
+		Help: "The total number of ssh-portal-api requests received",
 	})
 )
 

--- a/internal/sshserver/authhandler.go
+++ b/internal/sshserver/authhandler.go
@@ -29,12 +29,12 @@ var (
 
 var (
 	authAttemptsTotal = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "authentication_attempts_total",
-		Help: "The total number of authentication attempts",
+		Name: "sshportal_authentication_attempts_total",
+		Help: "The total number of ssh-portal authentication attempts",
 	})
 	authSuccessTotal = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "authentication_success_total",
-		Help: "The total number of successful authentication",
+		Name: "sshportal_authentication_success_total",
+		Help: "The total number of successful ssh-portal authentications",
 	})
 )
 

--- a/internal/sshserver/sessionhandler.go
+++ b/internal/sshserver/sessionhandler.go
@@ -12,8 +12,8 @@ import (
 
 var (
 	sessionTotal = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "session_total",
-		Help: "The total number of ssh sessions started",
+		Name: "sshportal_sessions_total",
+		Help: "The total number of ssh-portal sessions started",
 	})
 )
 

--- a/internal/sshtoken/authhandler.go
+++ b/internal/sshtoken/authhandler.go
@@ -25,15 +25,15 @@ type LagoonDBService interface {
 
 var (
 	authnAttemptsTotal = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "authentication_attempts_total",
-		Help: "The total number of authentication attempts",
+		Name: "sshtoken_authentication_attempts_total",
+		Help: "The total number of ssh-token authentication attempts",
 	})
 	authnSuccessTotal = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "authentication_success_total",
-		Help: "The total number of successful authentication attempts",
+		Name: "sshtoken_authentication_success_total",
+		Help: "The total number of successful ssh-token authentications",
 	})
 	authnAttemptsNonLagoonUser = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "authentication_attempts_non_lagoon_user",
+		Name: "sshtoken_authentication_attempts_non_lagoon_user",
 		Help: "The total number of failed authentication attempts with a user other than lagoon",
 	})
 )

--- a/internal/sshtoken/sessionhandler.go
+++ b/internal/sshtoken/sessionhandler.go
@@ -18,12 +18,12 @@ type KeycloakService interface {
 
 var (
 	sessionTotal = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "session_total",
-		Help: "The total number of ssh sessions started",
+		Name: "sshtoken_sessions_total",
+		Help: "The total number of ssh-token sessions started",
 	})
 	tokensGeneratedTotal = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "tokens_generated_total",
-		Help: "The total number of Lagoon authentication tokens generated",
+		Name: "sshtoken_tokens_generated_total",
+		Help: "The total number of ssh-token user access tokens generated",
 	})
 )
 


### PR DESCRIPTION
These metrics are never presented in a real service but they are built together when generating coverage reports.

This would be a breaking change if ssh-portal was part of any Lagoon release.