### PR TITLE
feat: add support in ssh-token for "grant" command

### DIFF
--- a/internal/keycloak/useraccesstoken.go
+++ b/internal/keycloak/useraccesstoken.go
@@ -2,6 +2,7 @@ package keycloak
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"path"
@@ -12,13 +13,10 @@ import (
 	"golang.org/x/oauth2"
 )
 
-// UserAccessToken queries Keycloak given the user UUID, and returns an access
-// token. Authorized party for this token is auth-server. Authorization is done
-// by the Lagoon API.
-func (c *Client) UserAccessToken(ctx context.Context,
-	userUUID *uuid.UUID) (string, error) {
+func (c *Client) getUserToken(ctx context.Context,
+	userUUID *uuid.UUID) (*oauth2.Token, error) {
 	// set up tracing
-	ctx, span := otel.Tracer(pkgName).Start(ctx, "UserAccessToken")
+	ctx, span := otel.Tracer(pkgName).Start(ctx, "getUserToken")
 	defer span.End()
 	// get user token
 	tokenURL := *c.baseURL
@@ -41,12 +39,49 @@ func (c *Client) UserAccessToken(ctx context.Context,
 		// https://www.keycloak.org/docs/latest/securing_apps/#_token-exchange
 		oauth2.SetAuthURLParam("requested_subject", userUUID.String()))
 	if err != nil {
-		return "", fmt.Errorf("couldn't get user token: %v", err)
+		return nil, fmt.Errorf("couldn't get user token: %v", err)
 	}
 	// parse and extract verified attributes
 	_, err = c.validateTokenClaims(userToken)
 	if err != nil {
-		return "", fmt.Errorf("couldn't validate token claims: %v", err)
+		return nil, fmt.Errorf("couldn't validate token claims: %v", err)
+	}
+	return userToken, nil
+}
+
+// UserAccessTokenResponse queries Keycloak given the user UUID, and returns an
+// access token response containing both access_token and refresh_token.
+// Authorized party for these tokens is auth-server. Authorization is done by
+// the Lagoon API.
+func (c *Client) UserAccessTokenResponse(ctx context.Context,
+	userUUID *uuid.UUID) (string, error) {
+	// set up tracing
+	ctx, span := otel.Tracer(pkgName).Start(ctx, "UserAccessToken")
+	defer span.End()
+	// get user token
+	userToken, err := c.getUserToken(ctx, userUUID)
+	if err != nil {
+		return "", fmt.Errorf("couldn't get user token: %v", err)
+	}
+	data, err := json.Marshal(userToken)
+	if err != nil {
+		return "", fmt.Errorf("couldn't marshal user token: %v", err)
+	}
+	return string(data), nil
+}
+
+// UserAccessToken queries Keycloak given the user UUID, and returns an access
+// token. Authorized party for this token is auth-server. Authorization is done
+// by the Lagoon API.
+func (c *Client) UserAccessToken(ctx context.Context,
+	userUUID *uuid.UUID) (string, error) {
+	// set up tracing
+	ctx, span := otel.Tracer(pkgName).Start(ctx, "UserAccessToken")
+	defer span.End()
+	// get user token
+	userToken, err := c.getUserToken(ctx, userUUID)
+	if err != nil {
+		return "", fmt.Errorf("couldn't get user token: %v", err)
 	}
 	return userToken.AccessToken, nil
 }


### PR DESCRIPTION
This command returns the entire access token response as opposed to "token", which returns just the access token.

See https://www.rfc-editor.org/rfc/rfc6749#section-4.1.4 for details