### PR TITLE
Return ssh-portal endpoint on attempted shell access through ssh-token service

### DIFF
--- a/cmd/ssh-token/serve.go
+++ b/cmd/ssh-token/serve.go
@@ -17,17 +17,19 @@ import (
 
 // ServeCmd represents the serve command.
 type ServeCmd struct {
-	APIDBAddress         string `kong:"required,env='API_DB_ADDRESS',help='Lagoon API DB Address (host[:port])'"`
-	APIDBDatabase        string `kong:"default='infrastructure',env='API_DB_DATABASE',help='Lagoon API DB Database Name'"`
-	APIDBPassword        string `kong:"required,env='API_DB_PASSWORD',help='Lagoon API DB Password'"`
-	APIDBUsername        string `kong:"default='api',env='API_DB_USERNAME',help='Lagoon API DB Username'"`
-	KeycloakBaseURL      string `kong:"required,env='KEYCLOAK_BASE_URL',help='Keycloak Base URL'"`
-	KeycloakClientID     string `kong:"default='auth-server',env='KEYCLOAK_AUTH_SERVER_CLIENT_ID',help='Keycloak OAuth2 Client ID'"`
-	KeycloakClientSecret string `kong:"required,env='KEYCLOAK_AUTH_SERVER_CLIENT_SECRET',help='Keycloak OAuth2 Client Secret'"`
-	SSHServerPort        uint   `kong:"default='2222',env='SSH_SERVER_PORT',help='Port the SSH server will listen on for SSH client connections'"`
-	HostKeyECDSA         string `kong:"env='HOST_KEY_ECDSA',help='PEM encoded ECDSA host key'"`
-	HostKeyED25519       string `kong:"env='HOST_KEY_ED25519',help='PEM encoded Ed25519 host key'"`
-	HostKeyRSA           string `kong:"env='HOST_KEY_RSA',help='PEM encoded RSA host key'"`
+	APIDBAddress                   string `kong:"required,env='API_DB_ADDRESS',help='Lagoon API DB Address (host[:port])'"`
+	APIDBDatabase                  string `kong:"default='infrastructure',env='API_DB_DATABASE',help='Lagoon API DB Database Name'"`
+	APIDBPassword                  string `kong:"required,env='API_DB_PASSWORD',help='Lagoon API DB Password'"`
+	APIDBUsername                  string `kong:"default='api',env='API_DB_USERNAME',help='Lagoon API DB Username'"`
+	KeycloakBaseURL                string `kong:"required,env='KEYCLOAK_BASE_URL',help='Keycloak Base URL'"`
+	KeycloakTokenClientID          string `kong:"default='auth-server',env='KEYCLOAK_AUTH_SERVER_CLIENT_ID',help='Keycloak auth-server OAuth2 Client ID'"`
+	KeycloakTokenClientSecret      string `kong:"required,env='KEYCLOAK_AUTH_SERVER_CLIENT_SECRET',help='Keycloak auth-server OAuth2 Client Secret'"`
+	KeycloakPermissionClientID     string `kong:"default='service-api',env='KEYCLOAK_SERVICE_API_CLIENT_ID',help='Keycloak service-api OAuth2 Client ID'"`
+	KeycloakPermissionClientSecret string `kong:"env='KEYCLOAK_SERVICE_API_CLIENT_SECRET',help='Keycloak service-api OAuth2 Client Secret'"`
+	SSHServerPort                  uint   `kong:"default='2222',env='SSH_SERVER_PORT',help='Port the SSH server will listen on for SSH client connections'"`
+	HostKeyECDSA                   string `kong:"env='HOST_KEY_ECDSA',help='PEM encoded ECDSA host key'"`
+	HostKeyED25519                 string `kong:"env='HOST_KEY_ED25519',help='PEM encoded Ed25519 host key'"`
+	HostKeyRSA                     string `kong:"env='HOST_KEY_RSA',help='PEM encoded RSA host key'"`
 }
 
 // Run the serve command to ssh-portal API requests.
@@ -48,13 +50,19 @@ func (cmd *ServeCmd) Run(log *zap.Logger) error {
 	dbConf.User = cmd.APIDBUsername
 	ldb, err := lagoondb.NewClient(ctx, dbConf.FormatDSN())
 	if err != nil {
-		return fmt.Errorf("couldn't init lagoon DBClient: %v", err)
+		return fmt.Errorf("couldn't init lagoonDB client: %v", err)
 	}
-	// init keycloak client
-	k, err := keycloak.NewClient(ctx, log, cmd.KeycloakBaseURL,
-		cmd.KeycloakClientID, cmd.KeycloakClientSecret)
+	// init token / auth-server keycloak client
+	keycloakToken, err := keycloak.NewClient(ctx, log, cmd.KeycloakBaseURL,
+		cmd.KeycloakTokenClientID, cmd.KeycloakTokenClientSecret)
 	if err != nil {
-		return fmt.Errorf("couldn't init keycloak Client: %v", err)
+		return fmt.Errorf("couldn't init keycloak token client: %v", err)
+	}
+	// init permission / service-api keycloak client
+	keycloakPermission, err := keycloak.NewClient(ctx, log, cmd.KeycloakBaseURL,
+		cmd.KeycloakPermissionClientID, cmd.KeycloakPermissionClientSecret)
+	if err != nil {
+		return fmt.Errorf("couldn't init keycloak permission client: %v", err)
 	}
 	// start listening on TCP port
 	l, err := net.Listen("tcp", fmt.Sprintf(":%d", cmd.SSHServerPort))
@@ -63,11 +71,13 @@ func (cmd *ServeCmd) Run(log *zap.Logger) error {
 	}
 	// check for persistent host key arguments
 	var hostkeys [][]byte
-	for _, hk := range []string{cmd.HostKeyECDSA, cmd.HostKeyED25519, cmd.HostKeyRSA} {
+	for _, hk := range []string{cmd.HostKeyECDSA, cmd.HostKeyED25519,
+		cmd.HostKeyRSA} {
 		if len(hk) > 0 {
 			hostkeys = append(hostkeys, []byte(hk))
 		}
 	}
 	// start serving SSH token requests
-	return sshtoken.Serve(ctx, log, l, ldb, k, hostkeys)
+	return sshtoken.Serve(ctx, log, l, ldb, keycloakToken, keycloakPermission,
+		hostkeys)
 }

--- a/internal/lagoondb/client.go
+++ b/internal/lagoondb/client.go
@@ -1,3 +1,4 @@
+// Package lagoondb provides an interface to the Lagoon API database.
 package lagoondb
 
 import (
@@ -69,7 +70,8 @@ func (c *Client) EnvironmentByNamespaceName(ctx context.Context, name string) (*
 		project.id AS project_id,
 		project.name AS project_name
 	FROM environment JOIN project ON environment.project = project.id
-	WHERE environment.openshift_project_name = ?`, name)
+	WHERE environment.openshift_project_name = ?
+	LIMIT 1`, name)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, ErrNoResult

--- a/internal/sshportalapi/sshportal.go
+++ b/internal/sshportalapi/sshportal.go
@@ -111,11 +111,6 @@ func sshportal(ctx context.Context, log *zap.Logger, c *nats.EncodedConn,
 				zap.Error(err))
 			return
 		}
-		log.Debug("keycloak query response",
-			zap.Strings("realmRoles", realmRoles),
-			zap.Strings("userGroups", userGroups),
-			zap.Any("groupProjectIDs", groupProjectIDs),
-			zap.String("userUUID", user.UUID.String()))
 		// calculate permission
 		ok := permission.UserCanSSHToEnvironment(ctx, env, realmRoles, userGroups,
 			groupProjectIDs)

--- a/internal/sshserver/sessionhandler.go
+++ b/internal/sshserver/sessionhandler.go
@@ -44,11 +44,7 @@ func sshifyCommand(sftp bool, cmd []string) []string {
 func sessionHandler(log *zap.Logger, c *k8s.Client, sftp bool) ssh.Handler {
 	return func(s ssh.Session) {
 		sessionTotal.Inc()
-		sid, ok := s.Context().Value(ssh.ContextKeySessionID).(string)
-		if !ok {
-			log.Warn("couldn't get session ID")
-			return
-		}
+		sid := s.Context().SessionID()
 		// start the command
 		log.Debug("starting command exec",
 			zap.String("sessionID", sid),

--- a/internal/sshtoken/sessionhandler.go
+++ b/internal/sshtoken/sessionhandler.go
@@ -2,19 +2,30 @@ package sshtoken
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/gliderlabs/ssh"
 	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/uselagoon/ssh-portal/internal/lagoondb"
+	"github.com/uselagoon/ssh-portal/internal/permission"
 	"go.uber.org/zap"
 )
 
-// KeycloakService provides methods for querying the Keycloak API.
-type KeycloakService interface {
+// KeycloakTokenService provides methods for querying the Keycloak API for user
+// access tokens.
+type KeycloakTokenService interface {
 	UserAccessTokenResponse(context.Context, *uuid.UUID) (string, error)
 	UserAccessToken(context.Context, *uuid.UUID) (string, error)
+}
+
+// KeycloakPermissionService provides methods for querying the Keycloak API for
+// permission information contained in service-api user tokens.
+type KeycloakPermissionService interface {
+	UserRolesAndGroups(context.Context, *uuid.UUID) ([]string, []string,
+		map[string][]int, error)
 }
 
 var (
@@ -26,118 +37,278 @@ var (
 		Name: "sshtoken_tokens_generated_total",
 		Help: "The total number of ssh-token user access tokens generated",
 	})
+	redirectsTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "sshtoken_redirects_total",
+		Help: "The total number of ssh redirect responses served",
+	})
 )
 
-// sessionHandler returns a ssh.Handler which writes a Lagoon access token to
-// the session stream and then closes the connection.
-func sessionHandler(log *zap.Logger, k KeycloakService) ssh.Handler {
-	return func(s ssh.Session) {
-		sessionTotal.Inc()
-		// extract required info from the session context
-		sid, ok := s.Context().Value(ssh.ContextKeySessionID).(string)
-		if !ok {
-			log.Warn("couldn't get session ID from context",
-				zap.String("sessionID", sid))
-			_, err := fmt.Fprintf(s.Stderr(), "internal error. SID: %s\n", sid)
-			if err != nil {
-				log.Debug("couldn't write error message to session stream",
-					zap.String("sessionID", sid),
-					zap.Error(err))
-			}
-			return
-		}
-		uid, ok := s.Context().Value(userUUID).(*uuid.UUID)
-		if !ok {
-			log.Warn("couldn't get user UUID from context",
-				zap.String("sessionID", sid))
-			_, err := fmt.Fprintf(s.Stderr(), "internal error. SID: %s\n", sid)
-			if err != nil {
-				log.Debug("couldn't write error message to session stream",
-					zap.String("sessionID", sid),
-					zap.Error(err))
-			}
-			return
-		}
-		// valid commands:
-		// - grant: returns a full access token response as per
-		//   https://www.rfc-editor.org/rfc/rfc6749#section-4.1.4
-		// - token: returns a bare access token (the contents of the access_token
-		//   field inside a full token access token response)
-		cmd := s.Command()
-		if len(cmd) != 1 {
-			log.Debug("too many arguments",
-				zap.Strings("command", cmd),
-				zap.String("sessionID", sid))
-			_, err := fmt.Fprintf(s.Stderr(),
-				"invalid command: only a single argument is supported. SID: %s\n", sid)
-			if err != nil {
-				log.Debug("couldn't write error message to session stream",
-					zap.String("sessionID", sid),
-					zap.Error(err))
-			}
-			return
-		}
-		// get response
-		var response string
-		var err error
-		switch cmd[0] {
-		case "grant":
-			response, err = k.UserAccessTokenResponse(s.Context(), uid)
-			if err != nil {
-				log.Warn("couldn't get user access token response",
-					zap.String("sessionID", sid),
-					zap.String("userUUID", uid.String()),
-					zap.Error(err))
-				_, err = fmt.Fprintf(s.Stderr(),
-					"internal error. SID: %s\n", sid)
-				if err != nil {
-					log.Debug("couldn't write error message to session stream",
-						zap.String("sessionID", sid),
-						zap.Error(err))
-				}
-				return
-			}
-		case "token":
-			response, err = k.UserAccessToken(s.Context(), uid)
-			if err != nil {
-				log.Warn("couldn't get user access token",
-					zap.String("sessionID", sid),
-					zap.String("userUUID", uid.String()),
-					zap.Error(err))
-				_, err = fmt.Fprintf(s.Stderr(),
-					"internal error. SID: %s\n", sid)
-				if err != nil {
-					log.Debug("couldn't write error message to session stream",
-						zap.String("sessionID", sid),
-						zap.Error(err))
-				}
-				return
-			}
-		default:
-			log.Debug("invalid command",
-				zap.Strings("command", cmd),
-				zap.String("sessionID", sid))
-			_, err := fmt.Fprintf(s.Stderr(),
-				"invalid command: only \"grant\" and \"token\" are supported. SID: %s\n", sid)
-			if err != nil {
-				log.Debug("couldn't write error message to session stream",
-					zap.String("sessionID", sid),
-					zap.Error(err))
-			}
-			return
-		}
-		// send response
-		_, err = fmt.Fprintf(s, "%s\n", response)
+// tokenSession returns a bare access token or full access token response based
+// on the user ID
+func tokenSession(s ssh.Session, log *zap.Logger,
+	keycloakToken KeycloakTokenService, uid *uuid.UUID) {
+	// valid commands:
+	// - grant: returns a full access token response as per
+	//   https://www.rfc-editor.org/rfc/rfc6749#section-4.1.4
+	// - token: returns a bare access token (the contents of the access_token
+	//   field inside a full token access token response)
+	sid := s.Context().SessionID()
+	cmd := s.Command()
+	if len(cmd) != 1 {
+		log.Debug("too many arguments",
+			zap.Strings("command", cmd),
+			zap.String("sessionID", sid),
+			zap.String("userUUID", uid.String()))
+		_, err := fmt.Fprintf(s.Stderr(),
+			"invalid command: only \"grant\" and \"token\" are supported. SID: %s\n", sid)
 		if err != nil {
-			log.Debug("couldn't write response to session stream",
+			log.Debug("couldn't write error message to session stream",
 				zap.String("sessionID", sid),
 				zap.String("userUUID", uid.String()),
 				zap.Error(err))
+		}
+		return
+	}
+	// get response
+	var response string
+	var err error
+	switch cmd[0] {
+	case "grant":
+		response, err = keycloakToken.UserAccessTokenResponse(s.Context(), uid)
+		if err != nil {
+			log.Warn("couldn't get user access token response",
+				zap.String("sessionID", sid),
+				zap.String("userUUID", uid.String()),
+				zap.Error(err))
+			_, err = fmt.Fprintf(s.Stderr(),
+				"internal error. SID: %s\n", sid)
+			if err != nil {
+				log.Debug("couldn't write error message to session stream",
+					zap.String("sessionID", sid),
+					zap.String("userUUID", uid.String()),
+					zap.Error(err))
+			}
 			return
 		}
-		tokensGeneratedTotal.Inc()
-		log.Info("generated access token for user",
+	case "token":
+		response, err = keycloakToken.UserAccessToken(s.Context(), uid)
+		if err != nil {
+			log.Warn("couldn't get user access token",
+				zap.String("sessionID", sid),
+				zap.String("userUUID", uid.String()),
+				zap.Error(err))
+			_, err = fmt.Fprintf(s.Stderr(),
+				"internal error. SID: %s\n", sid)
+			if err != nil {
+				log.Debug("couldn't write error message to session stream",
+					zap.String("sessionID", sid),
+					zap.String("userUUID", uid.String()),
+					zap.Error(err))
+			}
+			return
+		}
+	default:
+		log.Debug("invalid command",
+			zap.Strings("command", cmd),
 			zap.String("sessionID", sid),
 			zap.String("userUUID", uid.String()))
+		_, err := fmt.Fprintf(s.Stderr(),
+			"invalid command: only \"grant\" and \"token\" are supported. SID: %s\n", sid)
+		if err != nil {
+			log.Debug("couldn't write error message to session stream",
+				zap.String("sessionID", sid),
+				zap.String("userUUID", uid.String()),
+				zap.Error(err))
+		}
+		return
+	}
+	// send response
+	_, err = fmt.Fprintf(s, "%s\n", response)
+	if err != nil {
+		log.Debug("couldn't write response to session stream",
+			zap.String("sessionID", sid),
+			zap.String("userUUID", uid.String()),
+			zap.Error(err))
+		return
+	}
+	tokensGeneratedTotal.Inc()
+	log.Info("generated token for user",
+		zap.String("sessionID", sid),
+		zap.String("userUUID", uid.String()))
+}
+
+// redirectSession inspects the user string, and if it matches a namespace that
+// the user has access to, returns an error message to the user with the SSH
+// endpoint to use for ssh shell access. If the user doesn't have access to the
+// environment a generic error message is returned.
+func redirectSession(s ssh.Session, log *zap.Logger,
+	keycloakPermission KeycloakPermissionService, ldb LagoonDBService,
+	uid *uuid.UUID) {
+	sid := s.Context().SessionID()
+	// get the user roles and groups
+	realmRoles, userGroups, groupProjectIDs, err :=
+		keycloakPermission.UserRolesAndGroups(s.Context(), uid)
+	if err != nil {
+		log.Error("couldn't query user roles and groups",
+			zap.String("sessionID", sid),
+			zap.String("userUUID", uid.String()),
+			zap.Error(err))
+		_, err = fmt.Fprintf(s.Stderr(),
+			"This SSH server does not provide shell access. SID: %s\n", sid)
+		if err != nil {
+			log.Debug("couldn't write error message to session stream",
+				zap.String("sessionID", sid),
+				zap.String("userUUID", uid.String()),
+				zap.Error(err))
+		}
+		return
+	}
+	env, err := ldb.EnvironmentByNamespaceName(s.Context(), s.User())
+	if err != nil {
+		if errors.Is(err, lagoondb.ErrNoResult) {
+			log.Info("unknown namespace name",
+				zap.String("namespaceName", s.User()),
+				zap.String("userUUID", uid.String()),
+				zap.String("sessionID", sid),
+				zap.Error(err))
+		} else {
+			log.Error("couldn't get environment by namespace name",
+				zap.String("namespaceName", s.User()),
+				zap.String("userUUID", uid.String()),
+				zap.String("sessionID", sid),
+				zap.Error(err))
+		}
+		_, err = fmt.Fprintf(s.Stderr(),
+			"This SSH server does not provide shell access. SID: %s\n", sid)
+		if err != nil {
+			log.Debug("couldn't write error message to session stream",
+				zap.String("sessionID", sid),
+				zap.String("userUUID", uid.String()),
+				zap.Error(err))
+		}
+		return
+	}
+	// calculate permission
+	ok := permission.UserCanSSHToEnvironment(s.Context(), env, realmRoles,
+		userGroups, groupProjectIDs)
+	if !ok {
+		log.Info("user cannot SSH to environment",
+			zap.Int("environmentID", env.ID),
+			zap.Int("projectID", env.ProjectID),
+			zap.String("environmentName", env.Name),
+			zap.String("namespace", s.User()),
+			zap.String("projectName", env.ProjectName),
+			zap.String("sessionID", sid),
+			zap.String("userUUID", uid.String()))
+		log.Debug("user permissions",
+			zap.String("userUUID", uid.String()),
+			zap.Strings("realmRoles", realmRoles),
+			zap.Strings("userGroups", userGroups),
+			zap.Any("groupProjectIDs", groupProjectIDs))
+		_, err = fmt.Fprintf(s.Stderr(),
+			"This SSH server does not provide shell access. SID: %s\n", sid)
+		if err != nil {
+			log.Debug("couldn't write error message to session stream",
+				zap.String("sessionID", sid),
+				zap.String("userUUID", uid.String()),
+				zap.Error(err))
+		}
+		return
+	}
+	log.Info("user can SSH to environment",
+		zap.Int("environmentID", env.ID),
+		zap.Int("projectID", env.ProjectID),
+		zap.String("environmentName", env.Name),
+		zap.String("namespace", s.User()),
+		zap.String("projectName", env.ProjectName),
+		zap.String("sessionID", sid),
+		zap.String("userUUID", uid.String()))
+	log.Debug("user permissions",
+		zap.String("userUUID", uid.String()),
+		zap.Strings("realmRoles", realmRoles),
+		zap.Strings("userGroups", userGroups),
+		zap.Any("groupProjectIDs", groupProjectIDs))
+	sshHost, sshPort, err := ldb.SSHEndpointByEnvironmentID(s.Context(), env.ID)
+	if err != nil {
+		if errors.Is(err, lagoondb.ErrNoResult) {
+			log.Warn("no results for ssh endpoint by environment ID",
+				zap.String("namespaceName", s.User()),
+				zap.String("userUUID", uid.String()),
+				zap.String("sessionID", sid),
+				zap.Int("environmentID", env.ID),
+				zap.Error(err))
+		} else {
+			log.Error("couldn't get ssh endpoint by environment ID",
+				zap.String("namespaceName", s.User()),
+				zap.String("userUUID", uid.String()),
+				zap.String("sessionID", sid),
+				zap.Int("environmentID", env.ID),
+				zap.Error(err))
+		}
+		_, err = fmt.Fprintf(s.Stderr(),
+			"This SSH server does not provide shell access. SID: %s\n", sid)
+		if err != nil {
+			log.Debug("couldn't write error message to session stream",
+				zap.String("sessionID", sid),
+				zap.String("userUUID", uid.String()),
+				zap.Error(err))
+		}
+		return
+	}
+	preamble :=
+		"This SSH server does not provide shell access to your environment.\n" +
+			"To SSH into your environment use this endpoint:\n\n"
+	// send response
+	if sshPort == "22" {
+		_, err = fmt.Fprintf(s.Stderr(),
+			preamble+"\tssh %s@%s\n\nSID: %s\n",
+			s.User(), sshHost, sid)
+	} else {
+		_, err = fmt.Fprintf(s.Stderr(),
+			preamble+"\tssh -p %s %s@%s\n\nSID: %s\n",
+			sshPort, s.User(), sshHost, sid)
+	}
+	if err != nil {
+		log.Debug("couldn't write response to session stream",
+			zap.String("sessionID", sid),
+			zap.String("userUUID", uid.String()),
+			zap.Error(err))
+		return
+	}
+	redirectsTotal.Inc()
+	log.Info("redirected user to SSH portal endpoint",
+		zap.String("sessionID", sid),
+		zap.String("namespaceName", s.User()),
+		zap.String("userUUID", uid.String()),
+		zap.String("sshHost", sshHost),
+		zap.String("sshPort", sshPort))
+}
+
+// sessionHandler returns a ssh.Handler which writes a Lagoon access token to
+// the session stream and then closes the connection.
+func sessionHandler(log *zap.Logger, keycloakToken KeycloakTokenService,
+	keycloakPermission KeycloakPermissionService,
+	ldb LagoonDBService) ssh.Handler {
+	return func(s ssh.Session) {
+		sessionTotal.Inc()
+		// extract required info from the session context
+		uid, ok := s.Context().Value(userUUID).(*uuid.UUID)
+		if !ok {
+			log.Warn("couldn't get user UUID from context",
+				zap.String("sessionID", s.Context().SessionID()))
+			_, err := fmt.Fprintf(s.Stderr(), "internal error. SID: %s\n",
+				s.Context().SessionID())
+			if err != nil {
+				log.Debug("couldn't write error message to session stream",
+					zap.String("sessionID", s.Context().SessionID()),
+					zap.Error(err))
+			}
+			return
+		}
+		if s.User() == "lagoon" {
+			tokenSession(s, log, keycloakToken, uid)
+		} else {
+			redirectSession(s, log, keycloakPermission, ldb, uid)
+		}
 	}
 }


### PR DESCRIPTION
Update the `ssh-token` service to return a more helpful error message to a user who attempts to get a shell into a Lagoon environment through the `ssh-token` service. The error message now contains the ssh-portal endpoint that  the user should be using instead.

The ssh-portal endpoint message is only returned if the user actually has permission to access that environment. Otherwise a generic error is returned. This is designed to avoid leaking information about valid environment names.

Closes: #139 