### PR TITLE
fix: exclude deleted environments

### DIFF
--- a/internal/lagoondb/client.go
+++ b/internal/lagoondb/client.go
@@ -71,6 +71,7 @@ func (c *Client) EnvironmentByNamespaceName(ctx context.Context, name string) (*
 		project.name AS project_name
 	FROM environment JOIN project ON environment.project = project.id
 	WHERE environment.openshift_project_name = ?
+	AND environment.deleted = '0000-00-00 00:00:00'
 	LIMIT 1`, name)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {


### PR DESCRIPTION
The query to check if an environment exists currently returns the first matching environment, which could or could not be a deleted environment, in this case, removing the `limit 1` reveals the second environment
```
MariaDB [infrastructure]> SELECT
    ->     environment.environment_type AS type,
    ->     environment.id AS id,
    ->     environment.name AS name,
    -> environment.openshift_project_name AS namespace_name,
    ->     project.id AS project_id,
    -> project.name AS project_name
    -> FROM environment JOIN project ON environment.project = project.id
    -> WHERE environment.openshift_project_name = 'as-demo-test1-master-alt-test1'
    -> LIMIT 1;
+-------------+------+------------------+--------------------------------+------------+---------------+
| type        | id   | name             | namespace_name                 | project_id | project_name  |
+-------------+------+------------------+--------------------------------+------------+---------------+
| development | 1165 | master-alt-test1 | as-demo-test1-master-alt-test1 |         35 | as-demo-test1 |
+-------------+------+------------------+--------------------------------+------------+---------------+
1 row in set (0.001 sec)

MariaDB [infrastructure]> SELECT
    ->     environment.environment_type AS type,
    ->     environment.id AS id,
    ->     environment.name AS name,
    -> environment.openshift_project_name AS namespace_name,
    ->     project.id AS project_id,
    -> project.name AS project_name
    -> FROM environment JOIN project ON environment.project = project.id
    -> WHERE environment.openshift_project_name = 'as-demo-test1-master-alt-test1';
+-------------+------+------------------+--------------------------------+------------+---------------+
| type        | id   | name             | namespace_name                 | project_id | project_name  |
+-------------+------+------------------+--------------------------------+------------+---------------+
| development | 1165 | master-alt-test1 | as-demo-test1-master-alt-test1 |         35 | as-demo-test1 |
| production  | 1168 | master-alt-test1 | as-demo-test1-master-alt-test1 |         35 | as-demo-test1 |
+-------------+------+------------------+--------------------------------+------------+---------------+
```

updating the query to include the deleted check results in the correct environment being selected
```
MariaDB [infrastructure]> SELECT
    ->     environment.environment_type AS type,
    ->     environment.id AS id,
    ->     environment.name AS name,
    -> environment.openshift_project_name AS namespace_name,
    ->     project.id AS project_id,
    -> project.name AS project_name
    -> FROM environment JOIN project ON environment.project = project.id
    -> WHERE environment.openshift_project_name = 'as-demo-test1-master-alt-test1'
    -> AND environment.deleted = '0000-00-00 00:00:00'
    -> LIMIT 1;
+------------+------+------------------+--------------------------------+------------+---------------+
| type       | id   | name             | namespace_name                 | project_id | project_name  |
+------------+------+------------------+--------------------------------+------------+---------------+
| production | 1168 | master-alt-test1 | as-demo-test1-master-alt-test1 |         35 | as-demo-test1 |
+------------+------+------------------+--------------------------------+------------+---------------+
```

This matches closer to how the [API returns environments when selected by namespace](https://github.com/uselagoon/lagoon/blob/c301efa1ddeb263e3e48b54753bd1a67bc495c2f/services/api/src/resources/environment/sql.ts#L129-L135)