### PR TITLE
chore: add cover.out to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /dist
+/cover.out


### PR DESCRIPTION
The make cover target generates this file while calculating coverage.