### PR TITLE
feat: use slog instead of zap for structured logging

### DIFF
--- a/cmd/ssh-portal-api/main.go
+++ b/cmd/ssh-portal-api/main.go
@@ -1,9 +1,11 @@
-// Package main is the executable ssh-portal-api service.
+// Package main implements the ssh-portal-api service.
 package main
 
 import (
+	"log/slog"
+	"os"
+
 	"github.com/alecthomas/kong"
-	"go.uber.org/zap"
 )
 
 // CLI represents the command-line interface.
@@ -20,13 +22,13 @@ func main() {
 		kong.UsageOnError(),
 	)
 	// init logger
-	var log *zap.Logger
+	var log *slog.Logger
 	if cli.Debug {
-		log = zap.Must(zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel)))
+		log = slog.New(slog.NewJSONHandler(os.Stderr,
+			&slog.HandlerOptions{Level: slog.LevelDebug}))
 	} else {
-		log = zap.Must(zap.NewProduction())
+		log = slog.New(slog.NewJSONHandler(os.Stderr, nil))
 	}
-	defer log.Sync() //nolint:errcheck
 	// execute CLI
 	kctx.FatalIfErrorf(kctx.Run(log))
 }

--- a/cmd/ssh-portal-api/serve.go
+++ b/cmd/ssh-portal-api/serve.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os/signal"
 	"syscall"
 
@@ -12,7 +13,6 @@ import (
 	"github.com/uselagoon/ssh-portal/internal/metrics"
 	"github.com/uselagoon/ssh-portal/internal/rbac"
 	"github.com/uselagoon/ssh-portal/internal/sshportalapi"
-	"go.uber.org/zap"
 )
 
 // ServeCmd represents the serve command.
@@ -29,7 +29,7 @@ type ServeCmd struct {
 }
 
 // Run the serve command to ssh-portal API requests.
-func (cmd *ServeCmd) Run(log *zap.Logger) error {
+func (cmd *ServeCmd) Run(log *slog.Logger) error {
 	// metrics needs a separate context because deferred Shutdown() will exit
 	// immediately the context is done, which is the case for ctx on SIGTERM.
 	m := metrics.NewServer(log, ":9911")

--- a/cmd/ssh-portal/main.go
+++ b/cmd/ssh-portal/main.go
@@ -1,10 +1,12 @@
-// Package main implements the ssh-portal executable.
+// Package main implements the ssh-portal service.
 package main
 
 import (
+	"log/slog"
+	"os"
+
 	"github.com/alecthomas/kong"
 	"github.com/moby/spdystream"
-	"go.uber.org/zap"
 )
 
 // CLI represents the command-line interface.
@@ -23,13 +25,13 @@ func main() {
 		kong.UsageOnError(),
 	)
 	// init logger
-	var log *zap.Logger
+	var log *slog.Logger
 	if cli.Debug {
-		log = zap.Must(zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel)))
+		log = slog.New(slog.NewJSONHandler(os.Stderr,
+			&slog.HandlerOptions{Level: slog.LevelDebug}))
 	} else {
-		log = zap.Must(zap.NewProduction())
+		log = slog.New(slog.NewJSONHandler(os.Stderr, nil))
 	}
-	defer log.Sync() //nolint:errcheck
 	// execute CLI
 	kctx.FatalIfErrorf(kctx.Run(log))
 }

--- a/cmd/ssh-token/main.go
+++ b/cmd/ssh-token/main.go
@@ -1,9 +1,11 @@
-// Package main is the executable ssh-token service.
+// Package main implements the ssh-token service.
 package main
 
 import (
+	"log/slog"
+	"os"
+
 	"github.com/alecthomas/kong"
-	"go.uber.org/zap"
 )
 
 // CLI represents the command-line interface.
@@ -20,13 +22,13 @@ func main() {
 		kong.UsageOnError(),
 	)
 	// init logger
-	var log *zap.Logger
+	var log *slog.Logger
 	if cli.Debug {
-		log = zap.Must(zap.NewDevelopment(zap.AddStacktrace(zap.ErrorLevel)))
+		log = slog.New(slog.NewJSONHandler(os.Stderr,
+			&slog.HandlerOptions{Level: slog.LevelDebug}))
 	} else {
-		log = zap.Must(zap.NewProduction())
+		log = slog.New(slog.NewJSONHandler(os.Stderr, nil))
 	}
-	defer log.Sync() //nolint:errcheck
 	// execute CLI
 	kctx.FatalIfErrorf(kctx.Run(log))
 }

--- a/cmd/ssh-token/serve.go
+++ b/cmd/ssh-token/serve.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net"
 	"os/signal"
 	"syscall"
@@ -13,7 +14,6 @@ import (
 	"github.com/uselagoon/ssh-portal/internal/metrics"
 	"github.com/uselagoon/ssh-portal/internal/rbac"
 	"github.com/uselagoon/ssh-portal/internal/sshtoken"
-	"go.uber.org/zap"
 )
 
 // ServeCmd represents the serve command.
@@ -35,7 +35,7 @@ type ServeCmd struct {
 }
 
 // Run the serve command to ssh-portal API requests.
-func (cmd *ServeCmd) Run(log *zap.Logger) error {
+func (cmd *ServeCmd) Run(log *slog.Logger) error {
 	// metrics needs a separate context because deferred Shutdown() will exit
 	// immediately the context is done, which is the case for ctx on SIGTERM.
 	m := metrics.NewServer(log, ":9948")

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/prometheus/client_golang v1.18.0
 	github.com/zitadel/oidc/v3 v3.10.0
 	go.opentelemetry.io/otel v1.21.0
-	go.uber.org/zap v1.26.0
 	golang.org/x/crypto v0.18.0
 	golang.org/x/exp v0.0.0-20230817173708-d852ddb80c63
 	golang.org/x/oauth2 v0.16.0
@@ -68,7 +67,6 @@ require (
 	github.com/zitadel/schema v1.3.0 // indirect
 	go.opentelemetry.io/otel/metric v1.21.0 // indirect
 	go.opentelemetry.io/otel/trace v1.21.0 // indirect
-	go.uber.org/multierr v1.10.0 // indirect
 	golang.org/x/net v0.20.0 // indirect
 	golang.org/x/sys v0.16.0 // indirect
 	golang.org/x/term v0.16.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -168,12 +168,6 @@ go.opentelemetry.io/otel/metric v1.21.0 h1:tlYWfeo+Bocx5kLEloTjbcDwBuELRrIFxwdQ3
 go.opentelemetry.io/otel/metric v1.21.0/go.mod h1:o1p3CA8nNHW8j5yuQLdc1eeqEaPfzug24uvsyIEJRWM=
 go.opentelemetry.io/otel/trace v1.21.0 h1:WD9i5gzvoUPuXIXH24ZNBudiarZDKuekPqi/E8fpfLc=
 go.opentelemetry.io/otel/trace v1.21.0/go.mod h1:LGbsEB0f9LGjN+OZaQQ26sohbOmiMR+BaslueVtS/qQ=
-go.uber.org/goleak v1.2.0 h1:xqgm/S+aQvhWFTtR0XK3Jvg7z8kGV8P4X14IzwN3Eqk=
-go.uber.org/goleak v1.2.0/go.mod h1:XJYK+MuIchqpmGmUSAzotztawfKvYLUIgg7guXrwVUo=
-go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
-go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
-go.uber.org/zap v1.26.0 h1:sI7k6L95XOKS281NhVKOFCUNIvv9e0w4BF8N3u+tCRo=
-go.uber.org/zap v1.26.0/go.mod h1:dtElttAiwGvoJ/vj4IwHBS/gXsEu/pZ50mUIRWuG0so=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190911031432-227b76d455e7/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/internal/keycloak/client.go
+++ b/internal/keycloak/client.go
@@ -5,12 +5,11 @@ package keycloak
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"path"
 	"time"
-
-	"go.uber.org/zap"
 
 	"github.com/MicahParks/keyfunc/v2"
 	oidcClient "github.com/zitadel/oidc/v3/pkg/client"
@@ -24,12 +23,12 @@ type Client struct {
 	clientID     string
 	clientSecret string
 	jwks         *keyfunc.JWKS
-	log          *zap.Logger
+	log          *slog.Logger
 	oidcConfig   *oidc.DiscoveryConfiguration
 }
 
 // NewClient creates a new keycloak client for the lagoon realm.
-func NewClient(ctx context.Context, log *zap.Logger, keycloakURL, clientID,
+func NewClient(ctx context.Context, log *slog.Logger, keycloakURL, clientID,
 	clientSecret string) (*Client, error) {
 	// discover OIDC config
 	issuerURL, err := url.Parse(keycloakURL)

--- a/internal/keycloak/jwt_test.go
+++ b/internal/keycloak/jwt_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -14,7 +15,6 @@ import (
 	"github.com/alecthomas/assert/v2"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/uselagoon/ssh-portal/internal/keycloak"
-	"go.uber.org/zap"
 	"golang.org/x/oauth2"
 )
 
@@ -135,7 +135,7 @@ func TestUnmarshalLagoonClaims(t *testing.T) {
 
 func TestValidateTokenClaims(t *testing.T) {
 	// set up logger
-	log := zap.Must(zap.NewDevelopment())
+	log := slog.New(slog.NewJSONHandler(os.Stderr, nil))
 	// set up test cases
 	validClaims := keycloak.LagoonClaims{
 		AuthorizedParty: "auth-server",

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,17 +1,18 @@
+// Package metrics implements the prometheus metrics server.
 package metrics
 
 import (
+	"log/slog"
 	"net/http"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"go.uber.org/zap"
 )
 
 // NewServer returns a *http.Server serving prometheus metrics in a new
 // goroutine.
 // Caller should defer Shutdown() for cleanup.
-func NewServer(log *zap.Logger, addr string) *http.Server {
+func NewServer(log *slog.Logger, addr string) *http.Server {
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.Handler())
 	s := http.Server{
@@ -22,7 +23,7 @@ func NewServer(log *zap.Logger, addr string) *http.Server {
 	}
 	go func() {
 		if err := s.ListenAndServe(); err != http.ErrServerClosed {
-			log.Error("metrics server did not shut down cleanly", zap.Error(err))
+			log.Error("metrics server did not shut down cleanly", slog.Any("error", err))
 		}
 	}()
 	return &s

--- a/internal/sshserver/sessionhandler.go
+++ b/internal/sshserver/sessionhandler.go
@@ -3,6 +3,7 @@ package sshserver
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -10,7 +11,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/uselagoon/ssh-portal/internal/k8s"
-	"go.uber.org/zap"
 	"k8s.io/utils/exec"
 )
 
@@ -46,45 +46,38 @@ func getSSHIntent(sftp bool, cmd []string) []string {
 // handler is that the command is set to sftp-server. This implies that the
 // target container must have a sftp-server binary installed for sftp to work.
 // There is no support for a built-in sftp server.
-func sessionHandler(log *zap.Logger, c *k8s.Client,
+func sessionHandler(log *slog.Logger, c *k8s.Client,
 	sftp, logAccessEnabled bool) ssh.Handler {
 	return func(s ssh.Session) {
 		sessionTotal.Inc()
 		ctx := s.Context()
-		sid := ctx.SessionID()
+		log := log.With(slog.String("sessionID", ctx.SessionID()))
 		log.Debug("starting session",
-			zap.String("sessionID", sid),
-			zap.Strings("rawCommand", s.Command()),
-			zap.String("subsystem", s.Subsystem()),
+			slog.Any("rawCommand", s.Command()),
+			slog.String("subsystem", s.Subsystem()),
 		)
 		// parse the command line arguments to extract any service or container args
 		service, container, logs, rawCmd := parseConnectionParams(s.Command())
 		// validate the service and container
 		if err := k8s.ValidateLabelValue(service); err != nil {
 			log.Debug("invalid service name",
-				zap.String("service", service),
-				zap.String("sessionID", sid),
-				zap.Error(err))
+				slog.String("service", service),
+				slog.Any("error", err))
 			_, err = fmt.Fprintf(s.Stderr(), "invalid service name %s. SID: %s\r\n",
-				service, sid)
+				service, ctx.SessionID())
 			if err != nil {
-				log.Debug("couldn't write to session stream",
-					zap.String("sessionID", sid),
-					zap.Error(err))
+				log.Debug("couldn't write to session stream", slog.Any("error", err))
 			}
 			return
 		}
 		if err := k8s.ValidateLabelValue(container); err != nil {
 			log.Debug("invalid container name",
-				zap.String("container", container),
-				zap.String("sessionID", sid),
-				zap.Error(err))
+				slog.String("container", container),
+				slog.Any("error", err))
 			_, err = fmt.Fprintf(s.Stderr(), "invalid container name %s. SID: %s\r\n",
-				container, sid)
+				container, ctx.SessionID())
 			if err != nil {
-				log.Debug("couldn't write to session stream",
-					zap.String("sessionID", sid),
-					zap.Error(err))
+				log.Debug("couldn't write to session stream", slog.Any("error", err))
 			}
 			return
 		}
@@ -92,15 +85,12 @@ func sessionHandler(log *zap.Logger, c *k8s.Client,
 		deployment, err := c.FindDeployment(ctx, s.User(), service)
 		if err != nil {
 			log.Debug("couldn't find deployment for service",
-				zap.String("service", service),
-				zap.String("sessionID", sid),
-				zap.Error(err))
+				slog.String("service", service),
+				slog.Any("error", err))
 			_, err = fmt.Fprintf(s.Stderr(), "unknown service %s. SID: %s\r\n",
-				service, sid)
+				service, ctx.SessionID())
 			if err != nil {
-				log.Debug("couldn't write to session stream",
-					zap.String("sessionID", sid),
-					zap.Error(err))
+				log.Debug("couldn't write to session stream", slog.Any("error", err))
 			}
 			return
 		}
@@ -128,62 +118,51 @@ func sessionHandler(log *zap.Logger, c *k8s.Client,
 		if len(logs) != 0 {
 			if !logAccessEnabled {
 				log.Debug("logs access is not enabled",
-					zap.String("logsArgument", logs),
-					zap.String("sessionID", sid))
+					slog.String("logsArgument", logs))
 				_, err = fmt.Fprintf(s.Stderr(), "error executing command. SID: %s\r\n",
-					sid)
+					ctx.SessionID())
 				if err != nil {
-					log.Warn("couldn't send error to client",
-						zap.String("sessionID", sid),
-						zap.Error(err))
+					log.Warn("couldn't send error to client", slog.Any("error", err))
 				}
 				// Send a non-zero exit code to the client on internal logs error.
 				// OpenSSH uses 255 for this, 254 is an exec failure, so use 253 to
 				// differentiate this error.
 				if err = s.Exit(253); err != nil {
-					log.Warn("couldn't send exit code to client",
-						zap.String("sessionID", sid),
-						zap.Error(err))
+					log.Warn("couldn't send exit code to client", slog.Any("error", err))
 				}
 				return
 			}
 			follow, tailLines, err := parseLogsArg(service, logs, rawCmd)
 			if err != nil {
 				log.Debug("couldn't parse logs argument",
-					zap.String("logsArgument", logs),
-					zap.String("sessionID", sid),
-					zap.Error(err))
+					slog.String("logsArgument", logs),
+					slog.Any("error", err))
 				_, err = fmt.Fprintf(s.Stderr(), "error executing command. SID: %s\r\n",
-					sid)
+					ctx.SessionID())
 				if err != nil {
-					log.Warn("couldn't send error to client",
-						zap.String("sessionID", sid),
-						zap.Error(err))
+					log.Warn("couldn't send error to client", slog.Any("error", err))
 				}
 				// Send a non-zero exit code to the client on internal logs error.
 				// OpenSSH uses 255 for this, 254 is an exec failure, so use 253 to
 				// differentiate this error.
 				if err = s.Exit(253); err != nil {
-					log.Warn("couldn't send exit code to client",
-						zap.String("sessionID", sid),
-						zap.Error(err))
+					log.Warn("couldn't send exit code to client", slog.Any("error", err))
 				}
 				return
 			}
 			log.Info("sending logs to SSH client",
-				zap.Int("environmentID", eid),
-				zap.Int("projectID", pid),
-				zap.String("SSHFingerprint", fingerprint),
-				zap.String("container", container),
-				zap.String("deployment", deployment),
-				zap.String("environmentName", ename),
-				zap.String("namespace", s.User()),
-				zap.String("projectName", pname),
-				zap.String("sessionID", sid),
-				zap.Bool("follow", follow),
-				zap.Int64("tailLines", tailLines),
+				slog.Int("environmentID", eid),
+				slog.Int("projectID", pid),
+				slog.String("SSHFingerprint", fingerprint),
+				slog.String("container", container),
+				slog.String("deployment", deployment),
+				slog.String("environmentName", ename),
+				slog.String("namespace", s.User()),
+				slog.String("projectName", pname),
+				slog.Bool("follow", follow),
+				slog.Int64("tailLines", tailLines),
 			)
-			doLogs(ctx, log, s, deployment, container, follow, tailLines, c, sid)
+			doLogs(ctx, log, s, deployment, container, follow, tailLines, c)
 			return
 		}
 		// handle sftp and sh fallback
@@ -191,19 +170,18 @@ func sessionHandler(log *zap.Logger, c *k8s.Client,
 		// check if a pty was requested, and get the window size channel
 		_, winch, pty := s.Pty()
 		log.Info("executing SSH command",
-			zap.Bool("pty", pty),
-			zap.Int("environmentID", eid),
-			zap.Int("projectID", pid),
-			zap.String("SSHFingerprint", fingerprint),
-			zap.String("container", container),
-			zap.String("deployment", deployment),
-			zap.String("environmentName", ename),
-			zap.String("namespace", s.User()),
-			zap.String("projectName", pname),
-			zap.String("sessionID", sid),
-			zap.Strings("command", cmd),
+			slog.Bool("pty", pty),
+			slog.Int("environmentID", eid),
+			slog.Int("projectID", pid),
+			slog.String("SSHFingerprint", fingerprint),
+			slog.String("container", container),
+			slog.String("deployment", deployment),
+			slog.String("environmentName", ename),
+			slog.String("namespace", s.User()),
+			slog.String("projectName", pname),
+			slog.Any("command", cmd),
 		)
-		doExec(ctx, log, s, deployment, container, cmd, c, pty, winch, sid)
+		doExec(ctx, log, s, deployment, container, cmd, c, pty, winch)
 	}
 }
 
@@ -211,7 +189,7 @@ func sessionHandler(log *zap.Logger, c *k8s.Client,
 // embedded in ssh.Session at a regular interval. If the client fails to
 // respond, the channel is closed, and cancel is called.
 func startClientKeepalive(ctx context.Context, cancel context.CancelFunc,
-	log *zap.Logger, s ssh.Session) {
+	log *slog.Logger, s ssh.Session) {
 	ticker := time.NewTicker(2 * time.Second)
 	defer ticker.Stop()
 	for {
@@ -221,7 +199,7 @@ func startClientKeepalive(ctx context.Context, cancel context.CancelFunc,
 			// 	edc2ef4e418e514c99701451fae4428ec04ce538/serverloop.c#L127-L158
 			_, err := s.SendRequest("keepalive@openssh.com", true, nil)
 			if err != nil {
-				log.Debug("client closed connection", zap.Error(err))
+				log.Debug("client closed connection", slog.Any("error", err))
 				_ = s.Close()
 				cancel()
 				return
@@ -232,8 +210,8 @@ func startClientKeepalive(ctx context.Context, cancel context.CancelFunc,
 	}
 }
 
-func doLogs(ctx ssh.Context, log *zap.Logger, s ssh.Session, deployment,
-	container string, follow bool, tailLines int64, c *k8s.Client, sid string) {
+func doLogs(ctx ssh.Context, log *slog.Logger, s ssh.Session, deployment,
+	container string, follow bool, tailLines int64, c *k8s.Client) {
 	// Wrap the ssh.Context so we can cancel goroutines started from this
 	// function without affecting the SSH session.
 	childCtx, cancel := context.WithCancel(ctx)
@@ -249,62 +227,46 @@ func doLogs(ctx ssh.Context, log *zap.Logger, s ssh.Session, deployment,
 	go startClientKeepalive(childCtx, cancel, log, s)
 	err := c.Logs(childCtx, s.User(), deployment, container, follow, tailLines, s)
 	if err != nil {
-		log.Warn("couldn't send logs",
-			zap.String("sessionID", sid),
-			zap.Error(err))
+		log.Warn("couldn't send logs", slog.Any("error", err))
 		_, err = fmt.Fprintf(s.Stderr(), "error executing command. SID: %s\r\n",
-			sid)
+			ctx.SessionID())
 		if err != nil {
-			log.Warn("couldn't send error to client",
-				zap.String("sessionID", sid),
-				zap.Error(err))
+			log.Warn("couldn't send error to client", slog.Any("error", err))
 		}
 		// Send a non-zero exit code to the client on internal logs error.
 		// OpenSSH uses 255 for this, 254 is an exec failure, so use 253 to
 		// differentiate this error.
 		if err = s.Exit(253); err != nil {
-			log.Warn("couldn't send exit code to client",
-				zap.String("sessionID", sid),
-				zap.Error(err))
+			log.Warn("couldn't send exit code to client", slog.Any("error", err))
 		}
 	}
-	log.Debug("finished command logs", zap.String("sessionID", sid))
+	log.Debug("finished command logs")
 }
 
-func doExec(ctx ssh.Context, log *zap.Logger, s ssh.Session, deployment,
+func doExec(ctx ssh.Context, log *slog.Logger, s ssh.Session, deployment,
 	container string, cmd []string, c *k8s.Client, pty bool,
-	winch <-chan ssh.Window, sid string) {
+	winch <-chan ssh.Window) {
 	err := c.Exec(ctx, s.User(), deployment, container, cmd, s,
 		s.Stderr(), pty, winch)
 	if err != nil {
 		if exitErr, ok := err.(exec.ExitError); ok {
-			log.Debug("couldn't execute command",
-				zap.String("sessionID", sid),
-				zap.Error(err))
+			log.Debug("couldn't execute command", slog.Any("error", err))
 			if err = s.Exit(exitErr.ExitStatus()); err != nil {
-				log.Warn("couldn't send exit code to client",
-					zap.String("sessionID", sid),
-					zap.Error(err))
+				log.Warn("couldn't send exit code to client", slog.Any("error", err))
 			}
 		} else {
-			log.Warn("couldn't execute command",
-				zap.String("sessionID", sid),
-				zap.Error(err))
+			log.Warn("couldn't execute command", slog.Any("error", err))
 			_, err = fmt.Fprintf(s.Stderr(), "error executing command. SID: %s\r\n",
-				sid)
+				ctx.SessionID())
 			if err != nil {
-				log.Warn("couldn't send error to client",
-					zap.String("sessionID", sid),
-					zap.Error(err))
+				log.Warn("couldn't send error to client", slog.Any("error", err))
 			}
 			// Send a non-zero exit code to the client on internal exec error.
 			// OpenSSH uses 255 for this, so use 254 to differentiate the error.
 			if err = s.Exit(254); err != nil {
-				log.Warn("couldn't send exit code to client",
-					zap.String("sessionID", sid),
-					zap.Error(err))
+				log.Warn("couldn't send exit code to client", slog.Any("error", err))
 			}
 		}
 	}
-	log.Debug("finished command exec", zap.String("sessionID", sid))
+	log.Debug("finished command exec")
 }

--- a/internal/sshtoken/serve.go
+++ b/internal/sshtoken/serve.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net"
 	"time"
 
@@ -12,7 +13,6 @@ import (
 	"github.com/uselagoon/ssh-portal/internal/keycloak"
 	"github.com/uselagoon/ssh-portal/internal/lagoondb"
 	"github.com/uselagoon/ssh-portal/internal/rbac"
-	"go.uber.org/zap"
 )
 
 // give an 8 second deadline to shut down cleanly.
@@ -26,7 +26,7 @@ type LagoonDBService interface {
 }
 
 // Serve contains the main ssh session logic
-func Serve(ctx context.Context, log *zap.Logger, l net.Listener,
+func Serve(ctx context.Context, log *slog.Logger, l net.Listener,
 	p *rbac.Permission, ldb *lagoondb.Client,
 	keycloakToken, keycloakPermission *keycloak.Client,
 	hostKeys [][]byte) error {
@@ -45,7 +45,7 @@ func Serve(ctx context.Context, log *zap.Logger, l net.Listener,
 		shutCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 		defer cancel()
 		if err := srv.Shutdown(shutCtx); err != nil {
-			log.Warn("couldn't shutdown cleanly", zap.Error(err))
+			log.Warn("couldn't shutdown cleanly", slog.Any("error", err))
 		}
 	}()
 	if err := srv.Serve(l); !errors.Is(ssh.ErrServerClosed, err) {


### PR DESCRIPTION
slog is part of the standard library, so prefer to remove the zap dependency.

A nice side-effect is removal of 100 lines of logging code :taco: :tada: 