### PR TITLE
feat: upgrade module to Go 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/uselagoon/ssh-portal
 
-go 1.21
+go 1.22
 
 require (
 	github.com/MicahParks/keyfunc/v2 v2.1.0


### PR DESCRIPTION
Go 1.22 brings changes to the way loop iteration works with inner
closures. So take advantage of this feature to remove redundancy.

https://go.dev/blog/loopvar-preview