### PR TITLE
chore: bump go version number in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/uselagoon/ssh-portal
 
-go 1.22
+go 1.22.2
 
 require (
 	github.com/MicahParks/keyfunc/v2 v2.1.0


### PR DESCRIPTION
Ensure the version number is compatible with the go.mod version
standard. This fixes a problem with CodeQL scans in the CI system.

https://go.dev/doc/toolchain#version
