### PR TITLE
chore: support read-only api-db connections

### DIFF
--- a/cmd/ssh-portal-api/serve.go
+++ b/cmd/ssh-portal-api/serve.go
@@ -22,10 +22,10 @@ const (
 
 // ServeCmd represents the serve command.
 type ServeCmd struct {
-	APIDBAddress         string `kong:"required,env='API_DB_ADDRESS',help='Lagoon API DB Address (host[:port])'"`
+	APIDBAddress         string `kong:"required,env='API_DB_RO_ADDRESS,API_DB_ADDRESS',help='Lagoon API DB Address (host[:port])'"`
 	APIDBDatabase        string `kong:"default='infrastructure',env='API_DB_DATABASE',help='Lagoon API DB Database Name'"`
-	APIDBPassword        string `kong:"required,env='API_DB_PASSWORD',help='Lagoon API DB Password'"`
-	APIDBUsername        string `kong:"default='api',env='API_DB_USERNAME',help='Lagoon API DB Username'"`
+	APIDBPassword        string `kong:"required,env='API_DB_RO_PASSWORD,API_DB_PASSWORD',help='Lagoon API DB Password'"`
+	APIDBUsername        string `kong:"default='api',env='API_DB_RO_USERNAME,API_DB_USERNAME',help='Lagoon API DB Username'"`
 	BlockDeveloperSSH    bool   `kong:"env='BLOCK_DEVELOPER_SSH',help='Disallow Developer SSH access'"`
 	KeycloakBaseURL      string `kong:"required,env='KEYCLOAK_BASE_URL',help='Keycloak Base URL'"`
 	KeycloakClientID     string `kong:"default='service-api',env='KEYCLOAK_SERVICE_API_CLIENT_ID',help='Keycloak OAuth2 Client ID'"`

--- a/cmd/ssh-token/serve.go
+++ b/cmd/ssh-token/serve.go
@@ -23,10 +23,10 @@ const (
 
 // ServeCmd represents the serve command.
 type ServeCmd struct {
-	APIDBAddress                   string `kong:"required,env='API_DB_ADDRESS',help='Lagoon API DB Address (host[:port])'"`
+	APIDBAddress                   string `kong:"required,env='API_DB_RO_ADDRESS,API_DB_ADDRESS',help='Lagoon API DB Address (host[:port])'"`
 	APIDBDatabase                  string `kong:"default='infrastructure',env='API_DB_DATABASE',help='Lagoon API DB Database Name'"`
-	APIDBPassword                  string `kong:"required,env='API_DB_PASSWORD',help='Lagoon API DB Password'"`
-	APIDBUsername                  string `kong:"default='api',env='API_DB_USERNAME',help='Lagoon API DB Username'"`
+	APIDBPassword                  string `kong:"required,env='API_DB_RO_PASSWORD,API_DB_PASSWORD',help='Lagoon API DB Password'"`
+	APIDBUsername                  string `kong:"default='api',env='API_DB_RO_USERNAME,API_DB_USERNAME',help='Lagoon API DB Username'"`
 	BlockDeveloperSSH              bool   `kong:"env='BLOCK_DEVELOPER_SSH',help='Disallow Developer SSH access'"`
 	HostKeyECDSA                   string `kong:"env='HOST_KEY_ECDSA',help='PEM encoded ECDSA host key'"`
 	HostKeyED25519                 string `kong:"env='HOST_KEY_ED25519',help='PEM encoded Ed25519 host key'"`


### PR DESCRIPTION
It would be preferable to support read-only access to the api-db.

This can occur two ways (in the future anyway):
* via a manually created read-only user - adding the `API_DB_RO_USERNAME` and `API_DB_RO_PASSWORD` variables to the deployment as additionalEnvs
* via a read-replica (more common in cloud installs) - by adding the `API_DB_RO_ADDRESS` variable to the deployment as additionalEnvs

Kong will resolve the vars in the declared order, so if there is no `_RO_` it will use the version in the chart

For clarity, I created an additional variable(s) to avoid reusing the `API_DB_PASSWORD` variable - as it is a write password in other services that need write access.

```
MariaDB [infrastructure]> CREATE USER 'readonly'@'%' IDENTIFIED BY 'password';
Query OK, 0 rows affected (0.003 sec)

MariaDB [infrastructure]> GRANT SELECT, SHOW VIEW ON infrastructure.* TO 'readonly'@'%';
Query OK, 0 rows affected (0.003 sec)
```