### PR TITLE
Update last used timestamp on ssh keys when used

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/uselagoon/ssh-portal
 go 1.22.2
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/MicahParks/keyfunc/v2 v2.1.0
 	github.com/alecthomas/assert/v2 v2.10.0
 	github.com/alecthomas/kong v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/MicahParks/keyfunc/v2 v2.1.0 h1:6ZXKb9Rp6qp1bDbJefnG7cTH8yMN1IC/4nf+GVjO99k=
 github.com/MicahParks/keyfunc/v2 v2.1.0/go.mod h1:rW42fi+xgLJ2FRRXAfNx9ZA8WpD4OeE/yHVMteCkw9k=
 github.com/alecthomas/assert/v2 v2.10.0 h1:jjRCHsj6hBJhkmhznrCzoNpbA3zqy0fYiUcYZP/GkPY=
@@ -79,6 +81,7 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/klauspost/compress v1.17.2 h1:RlWWUY/Dr4fL8qk9YG7DTZ7PDgME2V4csBXA8L/ixi4=
 github.com/klauspost/compress v1.17.2/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=

--- a/internal/lagoondb/client_test.go
+++ b/internal/lagoondb/client_test.go
@@ -1,0 +1,61 @@
+package lagoondb_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/alecthomas/assert/v2"
+	"github.com/uselagoon/ssh-portal/internal/lagoondb"
+)
+
+func TestLastUsed(t *testing.T) {
+	var testCases = map[string]struct {
+		fingerprint string
+		used        time.Time
+		usedString  string
+		expectError bool
+	}{
+		"right time": {
+			fingerprint: "SHA256:yARVMVDnP2B2QzTvE8eSs5ZZlkZEoMFEIKjtYv1adfU",
+			used:        time.Unix(1719825567, 0),
+			usedString:  "2024-07-01 09:19:27",
+			expectError: false,
+		},
+		"wrong time": {
+			fingerprint: "SHA256:yARVMVDnP2B2QzTvE8eSs5ZZlkZEoMFEIKjtYv1adfU",
+			used:        time.Unix(1719825567, 0),
+			usedString:  "2024-07-01 17:19:27",
+			expectError: true,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(tt *testing.T) {
+			// set up mocks
+			mockDB, mock, err := sqlmock.New()
+			assert.NoError(tt, err, name)
+			mock.ExpectExec(
+				`UPDATE ssh_key `+
+					`SET last_used = (.+) `+
+					`WHERE key_fingerprint = (.+)`).
+				WithArgs(tc.usedString, tc.fingerprint).
+				WillReturnResult(sqlmock.NewErrorResult(nil))
+			// execute expected database operations
+			db := lagoondb.NewClientFromDB(mockDB)
+			err = db.SSHKeyUsed(context.Background(), tc.fingerprint, tc.used)
+			if tc.expectError {
+				assert.Error(tt, err, name)
+			} else {
+				assert.NoError(tt, err, name)
+			}
+			// check expectations
+			err = mock.ExpectationsWereMet()
+			if tc.expectError {
+				assert.Error(tt, err, name)
+			} else {
+				assert.NoError(tt, err, name)
+			}
+		})
+	}
+}

--- a/internal/lagoondb/helper_test.go
+++ b/internal/lagoondb/helper_test.go
@@ -1,0 +1,11 @@
+package lagoondb
+
+import (
+	"database/sql"
+
+	"github.com/jmoiron/sqlx"
+)
+
+func NewClientFromDB(db *sql.DB) *Client {
+	return &Client{db: sqlx.NewDb(db, "mysql")}
+}

--- a/internal/sshportalapi/server.go
+++ b/internal/sshportalapi/server.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/nats-io/nats.go"
@@ -25,6 +26,7 @@ type LagoonDBService interface {
 	lagoon.DBService
 	EnvironmentByNamespaceName(context.Context, string) (*lagoondb.Environment, error)
 	UserBySSHFingerprint(context.Context, string) (*lagoondb.User, error)
+	SSHKeyUsed(context.Context, string, time.Time) error
 }
 
 // KeycloakService provides methods for querying the Keycloak API.

--- a/internal/sshportalapi/sshportal.go
+++ b/internal/sshportalapi/sshportal.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"time"
 
 	"github.com/nats-io/nats.go"
 	"github.com/prometheus/client_golang/prometheus"
@@ -104,6 +105,12 @@ func sshportal(
 				return
 			}
 			log.Error("couldn't query user by ssh fingerprint", slog.Any("error", err))
+			return
+		}
+		// update last_used
+		if err := l.SSHKeyUsed(ctx, query.SSHFingerprint, time.Now()); err != nil {
+			log.Error("couldn't update ssh key last used: %v",
+				slog.Any("error", err))
 			return
 		}
 		// get the user roles and groups

--- a/internal/sshtoken/authhandler.go
+++ b/internal/sshtoken/authhandler.go
@@ -3,6 +3,7 @@ package sshtoken
 import (
 	"errors"
 	"log/slog"
+	"time"
 
 	"github.com/gliderlabs/ssh"
 	"github.com/prometheus/client_golang/prometheus"
@@ -51,6 +52,12 @@ func pubKeyAuth(log *slog.Logger, ldb LagoonDBService) ssh.PublicKeyHandler {
 				log.Warn("couldn't query for user by SSH key fingerprint",
 					slog.Any("error", err))
 			}
+			return false
+		}
+		// update last_used
+		if err := ldb.SSHKeyUsed(ctx, fingerprint, time.Now()); err != nil {
+			log.Error("couldn't update ssh key last used: %v",
+				slog.Any("error", err))
 			return false
 		}
 		// The SSH key fingerprint was in the database so "authentication" was

--- a/internal/sshtoken/serve.go
+++ b/internal/sshtoken/serve.go
@@ -25,6 +25,7 @@ type LagoonDBService interface {
 	EnvironmentByNamespaceName(context.Context, string) (*lagoondb.Environment, error)
 	UserBySSHFingerprint(context.Context, string) (*lagoondb.User, error)
 	SSHEndpointByEnvironmentID(context.Context, int) (string, string, error)
+	SSHKeyUsed(context.Context, string, time.Time) error
 }
 
 // Serve contains the main ssh session logic


### PR DESCRIPTION
Update the `last_used` attribute of ssh keys using the same technique as https://github.com/uselagoon/lagoon/pull/3675:

* Convert time to a string to be parsed by MySQL to `DATETIME` column type.
* Use UTC timezone.
