### PR TITLE
fix: avoid spurious rate limit

### DIFF
--- a/internal/keycloak/groups.go
+++ b/internal/keycloak/groups.go
@@ -55,15 +55,14 @@ func (c *Client) rawGroups(ctx context.Context) ([]byte, error) {
 func (c *Client) GroupNameGroupIDMap(
 	ctx context.Context,
 ) (map[string]string, error) {
-	// rate limit keycloak API access
-	if err := c.limiter.Wait(ctx); err != nil {
-		return nil, fmt.Errorf("couldn't wait for limiter: %v", err)
-	}
 	// prefer to use cached value
 	if groupNameGroupIDMap, ok := c.groupCache.Get(); ok {
 		return groupNameGroupIDMap, nil
 	}
 	// otherwise get data from keycloak
+	if err := c.limiter.Wait(ctx); err != nil {
+		return nil, fmt.Errorf("couldn't wait for limiter: %v", err)
+	}
 	data, err := c.rawGroups(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't get groups from Keycloak API: %v", err)


### PR DESCRIPTION
Previously, group data retrieved from in-memory cache was counted
towards the keycloak API rate limit.

With this change, data retrieved from cache does not count towards the
rate limit because the cache does not actually hit the keycloak API.
