### PR TITLE
feat: support insecure tls connections if required

### DIFF
--- a/cmd/keycloak-debug/dumpgroups.go
+++ b/cmd/keycloak-debug/dumpgroups.go
@@ -14,6 +14,7 @@ import (
 // DumpGroupsCmd represents the dump-groups command.
 type DumpGroupsCmd struct {
 	KeycloakBaseURL      string `kong:"required,env='KEYCLOAK_BASE_URL',help='Keycloak Base URL'"`
+	KeycloakInsecureTLS  bool   `kong:"env='KEYCLOAK_INSECURE_TLS',help='Keycloak Insecure TLS'"`
 	KeycloakClientID     string `kong:"default='service-api',env='KEYCLOAK_SERVICE_API_CLIENT_ID',help='Keycloak OAuth2 Client ID'"`
 	KeycloakClientSecret string `kong:"required,env='KEYCLOAK_SERVICE_API_CLIENT_SECRET',help='Keycloak OAuth2 Client Secret'"`
 	KeycloakRateLimit    int    `kong:"default=10,env='KEYCLOAK_RATE_LIMIT',help='Keycloak API Rate Limit (requests/second)'"`
@@ -29,7 +30,8 @@ func (cmd *DumpGroupsCmd) Run(log *slog.Logger) error {
 		cmd.KeycloakBaseURL,
 		cmd.KeycloakClientID,
 		cmd.KeycloakClientSecret,
-		cmd.KeycloakRateLimit)
+		cmd.KeycloakRateLimit,
+		cmd.KeycloakInsecureTLS)
 	if err != nil {
 		return fmt.Errorf("couldn't init keycloak client: %v", err)
 	}

--- a/cmd/ssh-portal-api/serve.go
+++ b/cmd/ssh-portal-api/serve.go
@@ -28,6 +28,7 @@ type ServeCmd struct {
 	APIDBUsername        string `kong:"default='api',env='API_DB_USERNAME',help='Lagoon API DB Username'"`
 	BlockDeveloperSSH    bool   `kong:"env='BLOCK_DEVELOPER_SSH',help='Disallow Developer SSH access'"`
 	KeycloakBaseURL      string `kong:"required,env='KEYCLOAK_BASE_URL',help='Keycloak Base URL'"`
+	KeycloakInsecureTLS  bool   `kong:"env='KEYCLOAK_INSECURE_TLS',help='Keycloak Insecure TLS'"`
 	KeycloakClientID     string `kong:"default='service-api',env='KEYCLOAK_SERVICE_API_CLIENT_ID',help='Keycloak OAuth2 Client ID'"`
 	KeycloakClientSecret string `kong:"required,env='KEYCLOAK_SERVICE_API_CLIENT_SECRET',help='Keycloak OAuth2 Client Secret'"`
 	KeycloakRateLimit    int    `kong:"default=10,env='KEYCLOAK_RATE_LIMIT',help='Keycloak API Rate Limit (requests/second)'"`
@@ -55,7 +56,8 @@ func (cmd *ServeCmd) Run(log *slog.Logger) error {
 		cmd.KeycloakBaseURL,
 		cmd.KeycloakClientID,
 		cmd.KeycloakClientSecret,
-		cmd.KeycloakRateLimit)
+		cmd.KeycloakRateLimit,
+		cmd.KeycloakInsecureTLS)
 	if err != nil {
 		return fmt.Errorf("couldn't init keycloak client: %v", err)
 	}

--- a/cmd/ssh-token/serve.go
+++ b/cmd/ssh-token/serve.go
@@ -32,6 +32,7 @@ type ServeCmd struct {
 	HostKeyED25519                 string `kong:"env='HOST_KEY_ED25519',help='PEM encoded Ed25519 host key'"`
 	HostKeyRSA                     string `kong:"env='HOST_KEY_RSA',help='PEM encoded RSA host key'"`
 	KeycloakBaseURL                string `kong:"required,env='KEYCLOAK_BASE_URL',help='Keycloak Base URL'"`
+	KeycloakInsecureTLS            bool   `kong:"env='KEYCLOAK_INSECURE_TLS',help='Keycloak Insecure TLS'"`
 	KeycloakPermissionClientID     string `kong:"default='service-api',env='KEYCLOAK_SERVICE_API_CLIENT_ID',help='Keycloak service-api OAuth2 Client ID'"`
 	KeycloakPermissionClientSecret string `kong:"env='KEYCLOAK_SERVICE_API_CLIENT_SECRET',help='Keycloak service-api OAuth2 Client Secret'"`
 	KeycloakRateLimit              int    `kong:"default=10,env='KEYCLOAK_RATE_LIMIT',help='Keycloak API Rate Limit (requests/second)'"`
@@ -61,7 +62,8 @@ func (cmd *ServeCmd) Run(log *slog.Logger) error {
 		cmd.KeycloakBaseURL,
 		cmd.KeycloakTokenClientID,
 		cmd.KeycloakTokenClientSecret,
-		cmd.KeycloakRateLimit)
+		cmd.KeycloakRateLimit,
+		cmd.KeycloakInsecureTLS)
 	if err != nil {
 		return fmt.Errorf("couldn't init keycloak token client: %v", err)
 	}
@@ -70,7 +72,8 @@ func (cmd *ServeCmd) Run(log *slog.Logger) error {
 		cmd.KeycloakBaseURL,
 		cmd.KeycloakPermissionClientID,
 		cmd.KeycloakPermissionClientSecret,
-		cmd.KeycloakRateLimit)
+		cmd.KeycloakRateLimit,
+		cmd.KeycloakInsecureTLS)
 	if err != nil {
 		return fmt.Errorf("couldn't init keycloak permission client: %v", err)
 	}

--- a/internal/keycloak/ancestorgroups_test.go
+++ b/internal/keycloak/ancestorgroups_test.go
@@ -184,7 +184,8 @@ func TestAncestorGroups(t *testing.T) {
 				ts.URL,
 				"auth-server",
 				"",
-				10)
+				10,
+				false)
 			if err != nil {
 				tt.Fatal(err)
 			}

--- a/internal/keycloak/client.go
+++ b/internal/keycloak/client.go
@@ -4,6 +4,7 @@ package keycloak
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -73,12 +74,16 @@ func NewClient(
 	clientID,
 	clientSecret string,
 	rateLimit int,
+	insecureTLS bool,
 ) (*Client, error) {
 	// discover OIDC config
 	baseURL, err := url.Parse(keycloakURL)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't parse keycloak base URL %s: %v",
 			keycloakURL, err)
+	}
+	if insecureTLS {
+		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	}
 	issuerURL := *baseURL
 	issuerURL.Path = path.Join(issuerURL.Path, "auth/realms/lagoon")

--- a/internal/keycloak/jwt_test.go
+++ b/internal/keycloak/jwt_test.go
@@ -251,7 +251,7 @@ func TestValidateTokenClaims(t *testing.T) {
 			// NOTE: client secret is empty because it isn't used in this test, but
 			// client ID is checked against azp in the token.
 			k, err := keycloak.NewClient(context.Background(), log, ts.URL,
-				"auth-server", "", 10)
+				"auth-server", "", 10, false)
 			if err != nil {
 				tt.Fatal(err)
 			}

--- a/internal/keycloak/usergroups_test.go
+++ b/internal/keycloak/usergroups_test.go
@@ -201,7 +201,8 @@ func TestUserGroupIDRole(t *testing.T) {
 				ts.URL,
 				"auth-server",
 				"",
-				10)
+				10,
+				false)
 			if err != nil {
 				tt.Fatal(err)
 			}


### PR DESCRIPTION
Support for https://github.com/uselagoon/lagoon/pull/3860 and the enforcement of TLS for local development. There needs to be a way to have the ssh-portal ignore certificates if required.