### PR TITLE
Improve local development experience

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -9,7 +9,6 @@ builds:
     -s -w
     -X "main.commit={{.Commit}}"
     -X "main.date={{.Date}}"
-    -X "main.goVersion={{.Env.GOVERSION}}"
     -X "main.projectName={{.ProjectName}}"
     -X "main.version=v{{.Version}}"
   env:

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,12 @@ build:
 	# build a binary for the local architecture only
 	goreleaser build --verbose --clean --single-target --snapshot
 
+.PHONY: release-snapshot
+release-snapshot:
+	# build binaries for all architectures, and multi-arch docker images, but
+	# don't validate or publish anything
+	GITHUB_REPOSITORY=uselagoon goreleaser release --verbose --clean --snapshot
+
 .PHONY: lint
 lint:
 	golangci-lint run --enable gocritic

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ generate: mod-tidy
 
 .PHONY: build
 build:
-	GOVERSION=$$(go version) \
-						goreleaser build --clean --debug --single-target --snapshot
+	# build a binary for the local architecture only
+	goreleaser build --verbose --clean --single-target --snapshot
 
 .PHONY: lint
 lint:

--- a/README.md
+++ b/README.md
@@ -168,6 +168,17 @@ The build process requires [goreleaser](https://github.com/goreleaser/goreleaser
 
 `make release-snapshot` will build binaries and docker images for all configured architectures.
 
+### Build manually
+
+Regular `go build` / `docker build` also works with the right incantations:
+
+```bash
+# example manual build command for ssh-portal binary/image
+# adjust as required for other binaries/architectures
+CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o dist/ssh-portal ./cmd/ssh-portal
+docker build --build-arg=BINARY=dist/ssh-portal -t foo/ssh-portal:v99 --platform=linux/amd64 .
+```
+
 ### Running tests
 
 `make test` will run the test suite.

--- a/README.md
+++ b/README.md
@@ -160,6 +160,21 @@ This helps to correlate error messages reported by users with detailed errors in
 
 ## Development tips
 
+### Build locally
+
+The build process requires [goreleaser](https://github.com/goreleaser/goreleaser) 2.x to be installed in your path.
+
+`make build` will build a binary for your local architecture in `dist/`.
+
+`make release-snapshot` will build binaries and docker images for all configured architectures.
+
+### Running tests
+
+`make test` will run the test suite.
+It regenerates code, so requires [mockgen](https://github.com/uber-go/mock/) and [enumer](https://github.com/dmarkham/enumer/) to be installed in your path.
+
+Alternatively you can just run `go test -v ./...` manually to avoid regenerating any code.
+
 ### Debugging Keycloak permissions
 
 A command to debug Keycloak permissions locally is included in `./cmd/keycloak-debug`.

--- a/cmd/ssh-portal-api/version.go
+++ b/cmd/ssh-portal-api/version.go
@@ -3,13 +3,13 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"runtime"
 )
 
 // These variables are set by GoReleaser during the build.
 var (
 	commit      string
 	date        string
-	goVersion   string
 	projectName string
 	version     string
 )
@@ -31,7 +31,7 @@ func (*VersionCmd) Run() error {
 			version,
 			commit,
 			date,
-			goVersion,
+			runtime.Version(),
 		})
 	if err != nil {
 		return err

--- a/cmd/ssh-portal/version.go
+++ b/cmd/ssh-portal/version.go
@@ -3,13 +3,13 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"runtime"
 )
 
 // These variables are set by GoReleaser during the build.
 var (
 	commit      string
 	date        string
-	goVersion   string
 	projectName string
 	version     string
 )
@@ -31,7 +31,7 @@ func (*VersionCmd) Run() error {
 			version,
 			commit,
 			date,
-			goVersion,
+			runtime.Version(),
 		})
 	if err != nil {
 		return err

--- a/cmd/ssh-token/version.go
+++ b/cmd/ssh-token/version.go
@@ -3,13 +3,13 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"runtime"
 )
 
 // These variables are set by GoReleaser during the build.
 var (
 	commit      string
 	date        string
-	goVersion   string
 	projectName string
 	version     string
 )
@@ -31,7 +31,7 @@ func (*VersionCmd) Run() error {
 			version,
 			commit,
 			date,
-			goVersion,
+			runtime.Version(),
 		})
 	if err != nil {
 		return err


### PR DESCRIPTION
* update the `build` Makefile target to actually work with GoReleaser 2.
* add a `release-snapshot` target to also build multiarch binaries and docker images.
* document these targets in the README.
