### PR TITLE
chore: switch to actions/attest

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,11 +61,11 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     # attest artifacts
-    - uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
+    - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
       with:
         subject-checksums: ./dist/checksums.txt
     # attest images
-    - uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
+    - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
       with:
         subject-checksums: ./dist/digests.txt
         push-to-registry: true


### PR DESCRIPTION
actions/attest-build-provenance is deprecated
https://github.com/actions/attest-build-provenance/releases/tag/v4.0.0
